### PR TITLE
Added ConnectionConfig including tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Modern C++ wrapper for MySQL C API
 
 **Author**: [Tomas Nozicka](https://github.com/tnozicka), [*Seznam.cz*](https://github.com/seznam)
 
-Note: This library currently doesn't supports MySQL library version 8 and newer.
+Note: This library currently doesn't support MySQL library version 8 and newer.
 
 # Installation
 
@@ -106,8 +106,21 @@ Please be aware that tests must validate all possible cases and syntax and shoul
 You can look at some basic examples below:
 
 ## Connection
+Connection can be constructed either by passing all necessary arguments directly to `Connection` constructor or by passing `ConnectionConfiguration` object.
+
 ```c++
 Connection connection{"<database>", "<user>", "<password>", "<host>", "<port>"};
+```
+
+`ConnectionConfiguration` contains static factory methods used to build proper connection configuration for desired purpose, e.g. encrypted connection over TCP or connection over Unix socket.
+
+```c++
+auto tcpConfig = ConnectionConfiguration::getTcpConnectionConfiguration("<database>", "<user>", "<password>", "<host>", "<port>");
+auto tcpSslConfig = ConnectionConfiguration::getSslTcpConnectionConfiguration(SslConfiguration{}, "<database>", "<user>", "<password>", "<host>", "<port>");
+auto socketConfig = ConnectionConfiguration::getSocketConnectionConfiguration("<database>", "<user>", "<password>", "<socket>");
+auto socketSslConfig = ConnectionConfiguration::getSslSocketConnectionConfiguration(SslConfiguration{}, "<database>", "<user>", "<password>", "<socket>");
+
+Connection connection{tcpConfig};
 ```
 
 Connections are not thread-safe => use one connection per thread. If you intend to have multiple connection to one server consider using connection pool.
@@ -160,7 +173,7 @@ while (auto row = result.fetchRow())
 ```
 
 ### Escaping
-To escape variable manually you may use method connection.escapeString. Preferred way is using query stream manipulators:
+To escape variable manually you may use method `connection.escapeString`. Preferred way is using query stream manipulators:
 ```c++
 auto query = connection.makeQuery();
 query << escape << "ab'cd";  // escape - next argument will be escaped

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -10,6 +10,7 @@ ADD test_database.sql /docker-entrypoint-initdb.d/
 RUN \
 apt-get update && apt-get install -y \
     patch \
+    socat \
     supervisor \
 && rm -rf /var/lib/apt/lists/*
 
@@ -21,6 +22,13 @@ RUN patch /usr/local/bin/docker-entrypoint.sh /docker-entrypoint.sh.patch
 # Since docker-entrypoint.sh drops privileges, we need to point supervisord
 # to a directory with required privileges. In this case, /tmp will suffice.
 ADD supervisord.conf /etc/supervisor/supervisord.conf
+
+# Enable mysqld socket (for testing purposes)
+RUN echo "socket = /var/run/mysqld/mysqld.sock" >> /etc/mysql/conf.d/mysql.cnf
+
+# Tunnel 3307 port to previously defined socket
+ADD mysql-socket-tunnel-3307 /usr/sbin/mysql-socket-tunnel-3307
+EXPOSE 3307
 
 # Ensure that we are using correct entrypoint due to wild development of
 # mysql:latest

--- a/db/mysql-socket-tunnel-3307
+++ b/db/mysql-socket-tunnel-3307
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec socat TCP-LISTEN:3307,reuseaddr,fork UNIX-CLIENT:/var/run/mysqld/mysqld.sock

--- a/db/supervisord.conf
+++ b/db/supervisord.conf
@@ -16,3 +16,7 @@ serverurl=unix:///tmp/supervisor.sock
 [program:mysqld]
 command=/usr/sbin/mysqld
 autorestart=false
+
+[program:mysql-socket-tunnel-3307]
+command=/usr/sbin/mysql-socket-tunnel-3307
+autorestart=false

--- a/include/superior_mysqlpp/config.hpp
+++ b/include/superior_mysqlpp/config.hpp
@@ -1,0 +1,72 @@
+/*
+ * Author: Jiří Kozlovský
+ */
+
+#pragma once
+
+#include <string>
+
+#include <superior_mysqlpp/types/optional.hpp>
+
+namespace SuperiorMySqlpp
+{
+    struct SslConfiguration
+    {
+        const char* keyPath = nullptr;
+        const char* certificatePath = nullptr;
+        const char* certificationAuthorityPath = nullptr;
+        const char* trustedCertificateDirPath = nullptr;
+        const char* allowableCiphers = nullptr;
+    };
+
+    class ConnectionConfiguration {
+        private:
+            ConnectionConfiguration(const Optional<SslConfiguration>& _sslConfig, const std::string& _database, const std::string& _user, const std::string& _password,
+                    const std::string& _target, const std::uint16_t _port=0) :
+                sslConfig{_sslConfig},
+                usingSocket{_port == 0},
+                database{_database},
+                user{_user},
+                password{_password},
+                target{_target},
+                port{_port}
+            { }
+
+        public:
+
+            const Optional<SslConfiguration> sslConfig;
+
+            const bool usingSocket;
+
+            const std::string database;
+            const std::string user;
+            const std::string password;
+            const std::string target;
+            const std::uint16_t port;
+
+
+            static ConnectionConfiguration getSslTcpConnectionConfiguration(const SslConfiguration& sslConfig, const std::string& database,
+                    const std::string& user, const std::string& password, const std::string& host="localhost", std::uint16_t port=3306)
+            {
+                    return ConnectionConfiguration{sslConfig, database, user, password, host, port};
+            }
+
+            static ConnectionConfiguration getTcpConnectionConfiguration(const std::string& database, const std::string& user, const std::string& password,
+                    const std::string& host="localhost", std::uint16_t port=3306)
+            {
+                    return ConnectionConfiguration{{}, database, user, password, host, port};
+            }
+
+            static ConnectionConfiguration getSslSocketConnectionConfiguration(const SslConfiguration& sslConfig, const std::string& database,
+                    const std::string& user, const std::string& password, const std::string& socket="/var/run/mysqld/mysqld.sock")
+            {
+                    return ConnectionConfiguration{sslConfig, database, user, password, socket};
+            }
+
+            static ConnectionConfiguration getSocketConnectionConfiguration(const std::string& database, const std::string& user, const std::string& password,
+                    const std::string& socket="/var/run/mysqld/mysqld.sock")
+            {
+                    return ConnectionConfiguration{{}, database, user, password, socket};
+            }
+    };
+}

--- a/makefile
+++ b/makefile
@@ -72,7 +72,7 @@ endif
 
 test: test-basic test-extended
 
-	
+
 libsuperiormysqlpp.pc: libsuperiormysqlpp.pc.in makefile
 	sed \
          -e 's,@VERSION@,$(VERSION),' \

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -1,6 +1,7 @@
 libsuperiormysqlpp (0.3.3) UNRELEASED; urgency=medium
 
-  *
+  [ Radek Smejdir ]
+  * Add ConnectionConfiguration
 
  -- Michal Fizek <michal.fizek@firma.seznam.cz>  Mon, 23 Apr 2018 14:17:57 +0200
 

--- a/packages/debian-jessie/dpkg-jail/debian/control
+++ b/packages/debian-jessie/dpkg-jail/debian/control
@@ -6,7 +6,8 @@ Build-Depends: debhelper(>=9),
                g++(>=4.9.2),
                docker.io,
                libmysqlclient-dev,
-               libboost-system-dev(>=1.49.0)
+               libboost-system-dev(>=1.49.0),
+               socat
 Standards-Version: 3.7.2
 
 Package: libsuperiormysqlpp-dev

--- a/packages/debian-stretch/dpkg-jail/debian/control
+++ b/packages/debian-stretch/dpkg-jail/debian/control
@@ -6,7 +6,8 @@ Build-Depends: debhelper,
                clang-5.0,
                docker-ce,
                libmysqlclient-dev | libmariadb-dev (>= 10.2),
-               libboost-system-dev (>= 1.49.0)
+               libboost-system-dev (>= 1.49.0),
+               socat
 Standards-Version: 3.7.2
 
 Package: libsuperiormysqlpp-dev

--- a/packages/fedora-22/libsuperiormysqlpp.spec
+++ b/packages/fedora-22/libsuperiormysqlpp.spec
@@ -7,8 +7,8 @@ License:        LGPLv3+
 URL:            http://ftp.gnu.org/gnu/%{name}
 Source0:        http://ftp.gnu.org/gnu/%{name}/%{name}-%{version}.tar.gz
 
-BuildRequires:  docker, gcc-c++, community-mysql-devel, hostname, libasan, libubsan, tree, boost-devel >= 1.49.0
-      
+BuildRequires:  docker, gcc-c++, community-mysql-devel, hostname, libasan, libubsan, tree, boost-devel >= 1.49.0, socat
+
 Requires(post): info
 Requires(preun): info
 

--- a/packages/szn-debian-wheezy/dpkg-jail/debian/control
+++ b/packages/szn-debian-wheezy/dpkg-jail/debian/control
@@ -6,7 +6,8 @@ Build-Depends: debhelper(>=9),
                szn-g++(>=4.9.2),
                docker-engine,
                libmysqlclient-dev,
-               libboost-system-dev(>=1.49.0)
+               libboost-system-dev(>=1.49.0),
+               socat
 Standards-Version: 3.7.2
 
 Package: libsuperiormysqlpp-dev

--- a/tests/db_access/connection.cpp
+++ b/tests/db_access/connection.cpp
@@ -125,6 +125,30 @@ go_bandit([](){
         it("can use SSL", [&](){
             Connection connection{SslConfiguration{}, s.database, s.user, s.password, s.host, s.port};
         });
+
+        it("can use TCP ConnectionConfiguration without SSL", [&](){
+            ConnectionConfiguration tcpConfig = ConnectionConfiguration::getTcpConnectionConfiguration(s.database, s.user, s.password, s.host, s.port);
+
+            Connection connection{tcpConfig};
+        });
+
+        it("can use TCP ConnectionConfiguration with SSL", [&](){
+            ConnectionConfiguration tcpConfig = ConnectionConfiguration::getSslTcpConnectionConfiguration(SslConfiguration{}, s.database, s.user, s.password, s.host, s.port);
+
+            Connection connection{tcpConfig};
+        });
+
+        it("can use socketed ConnectionConfiguration without SSL", [&](){
+            ConnectionConfiguration socketConfig = ConnectionConfiguration::getSocketConnectionConfiguration(s.database, s.user, s.password, s.socket);
+
+            Connection connection{socketConfig};
+        });
+
+        it("can use socketed ConnectionConfiguration with SSL", [&](){
+            ConnectionConfiguration socketConfig = ConnectionConfiguration::getSslSocketConnectionConfiguration(SslConfiguration{}, s.database, s.user, s.password, s.socket);
+
+            Connection connection{socketConfig};
+        });
     });
 });
 

--- a/tests/db_access/settings.hpp
+++ b/tests/db_access/settings.hpp
@@ -17,6 +17,7 @@
 
 struct Setting
 {
+    std::string socket{""};
     std::string host{""};
     std::string user{"root"};
     std::string password{"password"};

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -35,14 +35,14 @@ public:
 
 void printUsage()
 {
-    std::cerr << "Usage: ./tester <MySqlIpAddress> <MySqlPort> <MySqlContainerId> [bandit-options...]" << std::endl;
+    std::cerr << "Usage: ./tester <MySqlIpAddress> <MySqlPort> <MySqlContainerId> <LocalFwdSocket> [bandit-options...]" << std::endl;
 }
 
 int main(int argc, char* argv[])
 {
-    if (argc < 4)
+    if (argc < 5)
     {
-        std::cerr << "Less than 3 arguments!" << std::endl;
+        std::cerr << "Less than 4 arguments!" << std::endl;
         printUsage();
         return 1;
     }
@@ -60,6 +60,7 @@ int main(int argc, char* argv[])
         return 1;
     }
     s.containerId = argv[3];
+    s.socket = argv[4];
 
     Singleton::getInstance();
 
@@ -69,6 +70,6 @@ int main(int argc, char* argv[])
     waitForMySql();
     std::cout << "MySQL is ready." << std::endl;
 
-    return bandit::run(argc-3, argv+3);
+    return bandit::run(argc-4, argv+4);
 }
 

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -10,8 +10,37 @@ docker run -d -P --name ${CONTAINER_NAME} ${IMAGE_NAME} #1>/dev/null
 MYSQL_HOST=`docker inspect --format='{{.NetworkSettings.IPAddress}}' ${CONTAINER_NAME}`
 set +e
 
-./tester ${MYSQL_HOST} 3306 ${CONTAINER_NAME} --reporter=spec
+LOCAL_TMP_SOCKET="/tmp/${CONTAINER_NAME}.sock"
+
+# Create local socket forwarded to docker's 3307 port where is the traffic forwarded to docker mysql socket
+socat "UNIX-LISTEN:$LOCAL_TMP_SOCKET,fork,reuseaddr,unlink-early,mode=777" \
+    TCP:$MYSQL_HOST:3307 &
+
+./tester ${MYSQL_HOST} 3306 ${CONTAINER_NAME} ${LOCAL_TMP_SOCKET} --reporter=spec
 RESULT=$?
 
+## TODO Add option to run test in manual mode.
+## It's needed to run docker in interactive mode to get `read` command working, just add `-i` option to docker run in main project's makefile.
+#echo
+#echo "To connect to test DB:
+#echo "  mysql -uroot -ppassword -h $MYSQL_HOST -P 3306"
+#echo "To manually test socket forwarding through 3307, try:"
+#echo "  mysql -uroot -ppassword -h $MYSQL_HOST -P 3307"
+#echo "  mysql -uroot -ppassword --socket $LOCAL_TMP_SOCKET"
+#echo "To run some test case again:"
+#echo "  ./tester ${MYSQL_HOST} 3306 ${CONTAINER_NAME} ${LOCAL_TMP_SOCKET} --reporter=spec --only=<test-name-substring>"
+#echo
+#read -p "Press Enter to continue .. (this will kill running docker & socat forwarding)" _
+#echo
+
+# Remove local socket forwarding (so kill last job put to background)
+kill $!
+
+echo "Removing temporary created docker container ..."
 docker rm -f ${CONTAINER_NAME}
+
+if [ ! "$?" -eq "0" ]; then
+    echo >&2 "Removing docker container '${CONTAINER_NAME}' failed"
+fi
+
 exit ${RESULT}


### PR DESCRIPTION
ConnectionConfig is a class which should solve the problem with ambiguity while calling Connection c'tor with only host / socket defined (compiler error)

Here is the default value for c'tor with socket unset for socket so that there is no more ambiguity and is added a ConnectionConfig class instead. It provides two static factory methods for both TCP Connection & Socketed Connection with as much default values as possible.

Tests were working in a way that the host (machine the tests are ran from) is connected to Dockerized MySQL server via TCP using Docker IP by default. 

So - in order to create tests for socketed connection I've come up with a socket -> socket tunnel via TCP. It works in a way that host creates socket, where the tests try to connect. This socket is only a traffic forwarder to 3307 port of the Docker instance of tested MySQL server. The docker instance has listener on port 3307 forwarding all traffic to mysqld socket. So there actually is a socketed connection - but relies on TCP. (Any ideas how to do socketed connection tests better while is the testing environment still being in Docker?)

The work was initiated by Issue #4 
