### PR TITLE
allow to ignore nullable bindings

### DIFF
--- a/include/superior_mysqlpp/connection.hpp
+++ b/include/superior_mysqlpp/connection.hpp
@@ -18,12 +18,14 @@ namespace SuperiorMySqlpp
              bool storeResult,
              ValidateMetadataMode validateMode,
              ValidateMetadataMode warnMode,
+             bool ignoreNullable,
              typename... Args>
     PreparedStatement<RBindings,
                       ParamBindings<std::decay_t<Args>...>,
                       storeResult,
                       validateMode,
-                      warnMode
+                      warnMode,
+                      ignoreNullable
                       > Connection::makePreparedStatement(const std::string& query, Args&&... args) &
     {
         return {*this, query, std::forward<Args>(args)...};
@@ -34,13 +36,15 @@ namespace SuperiorMySqlpp
              bool storeResult,
              ValidateMetadataMode validateMode,
              ValidateMetadataMode warnMode,
+             bool ignoreNullable,
              template<typename...> class RArgsTuple, template<typename...> class PArgsTuple,
              typename... RArgs, typename... PArgs>
     PreparedStatement<RBindings,
                       ParamBindings<std::decay_t<PArgs>...>,
                       storeResult,
                       validateMode,
-                      warnMode
+                      warnMode,
+                      ignoreNullable
                       > Connection::makePreparedStatement(const std::string& query,
                                                           FullInitTag tag, RArgsTuple<RArgs...>&& resultArgs,
                                                           PArgsTuple<PArgs...>&& paramArgs) &
@@ -49,8 +53,8 @@ namespace SuperiorMySqlpp
     }
 
 
-    template<bool storeResult, ValidateMetadataMode validateMode, ValidateMetadataMode warnMode>
-    DynamicPreparedStatement<storeResult, validateMode, warnMode> Connection::makeDynamicPreparedStatement(const std::string& query) &
+    template<bool storeResult, ValidateMetadataMode validateMode, ValidateMetadataMode warnMode, bool ignoreNullable>
+    DynamicPreparedStatement<storeResult, validateMode, warnMode, ignoreNullable> Connection::makeDynamicPreparedStatement(const std::string& query) &
     {
         return {*this, query};
     }

--- a/include/superior_mysqlpp/connection_def.hpp
+++ b/include/superior_mysqlpp/connection_def.hpp
@@ -124,24 +124,28 @@ namespace SuperiorMySqlpp
                  bool storeResult=detail::PreparedStatementsDefault::getStoreResult(),
                  ValidateMetadataMode validateMode=detail::PreparedStatementsDefault::getValidateMode(),
                  ValidateMetadataMode warnMode=detail::PreparedStatementsDefault::getWarnMode(),
+                 bool ignoreNullable=detail::PreparedStatementsDefault::getIgnoreNullable(),
                  typename... Args>
         PreparedStatement<RBindings,
                           ParamBindings<std::decay_t<Args>...>,
                           storeResult,
                           validateMode,
-                          warnMode
+                          warnMode,
+                          ignoreNullable
                           > makePreparedStatement(const std::string&, Args&&...) && = delete;
 
         template<typename RBindings=ResultBindings<>,
                  bool storeResult=detail::PreparedStatementsDefault::getStoreResult(),
                  ValidateMetadataMode validateMode=detail::PreparedStatementsDefault::getValidateMode(),
                  ValidateMetadataMode warnMode=detail::PreparedStatementsDefault::getWarnMode(),
+                 bool ignoreNullable=detail::PreparedStatementsDefault::getIgnoreNullable(),
                  typename... Args>
         PreparedStatement<RBindings,
                           ParamBindings<std::decay_t<Args>...>,
                           storeResult,
                           validateMode,
-                          warnMode
+                          warnMode,
+                          ignoreNullable
                           > makePreparedStatement(const std::string&, Args&&...) &;
 
 
@@ -150,6 +154,7 @@ namespace SuperiorMySqlpp
                  bool storeResult=detail::PreparedStatementsDefault::getStoreResult(),
                  ValidateMetadataMode validateMode=detail::PreparedStatementsDefault::getValidateMode(),
                  ValidateMetadataMode warnMode=detail::PreparedStatementsDefault::getWarnMode(),
+                 bool ignoreNullable=detail::PreparedStatementsDefault::getIgnoreNullable(),
                  template<typename...> class RArgsTuple, template<typename...> class PArgsTuple,
                  typename... RArgs, typename... PArgs
                  >
@@ -157,7 +162,8 @@ namespace SuperiorMySqlpp
                           ParamBindings<std::decay_t<PArgs>...>,
                           storeResult,
                           validateMode,
-                          warnMode
+                          warnMode,
+                          ignoreNullable
                           > makePreparedStatement(
                 const std::string&, FullInitTag, RArgsTuple<RArgs...>&&, PArgsTuple<PArgs...>&&) && = delete;
 
@@ -165,6 +171,7 @@ namespace SuperiorMySqlpp
                  bool storeResult=detail::PreparedStatementsDefault::getStoreResult(),
                  ValidateMetadataMode validateMode=detail::PreparedStatementsDefault::getValidateMode(),
                  ValidateMetadataMode warnMode=detail::PreparedStatementsDefault::getWarnMode(),
+                 bool ignoreNullable=detail::PreparedStatementsDefault::getIgnoreNullable(),
                  template<typename...> class RArgsTuple, template<typename...> class PArgsTuple,
                  typename... RArgs, typename... PArgs
                  >
@@ -172,7 +179,8 @@ namespace SuperiorMySqlpp
                           ParamBindings<std::decay_t<PArgs>...>,
                           storeResult,
                           validateMode,
-                          warnMode
+                          warnMode,
+                          ignoreNullable
                           > makePreparedStatement(
                 const std::string&, FullInitTag, RArgsTuple<RArgs...>&&, PArgsTuple<PArgs...>&&) &;
 
@@ -181,13 +189,15 @@ namespace SuperiorMySqlpp
 
         template<bool storeResult=detail::PreparedStatementsDefault::getStoreResult(),
                  ValidateMetadataMode validateMode=detail::PreparedStatementsDefault::getValidateMode(),
-                 ValidateMetadataMode warnMode=detail::PreparedStatementsDefault::getWarnMode()>
-        DynamicPreparedStatement<storeResult, validateMode, warnMode> makeDynamicPreparedStatement(const std::string& query) && = delete;
+                 ValidateMetadataMode warnMode=detail::PreparedStatementsDefault::getWarnMode(),
+                 bool ignoreNullable=detail::PreparedStatementsDefault::getIgnoreNullable()>
+        DynamicPreparedStatement<storeResult, validateMode, warnMode, ignoreNullable> makeDynamicPreparedStatement(const std::string& query) && = delete;
 
         template<bool storeResult=detail::PreparedStatementsDefault::getStoreResult(),
                  ValidateMetadataMode validateMode=detail::PreparedStatementsDefault::getValidateMode(),
-                 ValidateMetadataMode warnMode=detail::PreparedStatementsDefault::getWarnMode()>
-        DynamicPreparedStatement<storeResult, validateMode, warnMode> makeDynamicPreparedStatement(const std::string& query) &;
+                 ValidateMetadataMode warnMode=detail::PreparedStatementsDefault::getWarnMode(),
+                 bool ignoreNullable=detail::PreparedStatementsDefault::getIgnoreNullable()>
+        DynamicPreparedStatement<storeResult, validateMode, warnMode, ignoreNullable> makeDynamicPreparedStatement(const std::string& query) &;
 
 
         template<typename... Args>

--- a/include/superior_mysqlpp/dynamic_prepared_statement.hpp
+++ b/include/superior_mysqlpp/dynamic_prepared_statement.hpp
@@ -24,8 +24,8 @@
 
 namespace SuperiorMySqlpp
 {
-    template<bool storeResult, ValidateMetadataMode validateMode, ValidateMetadataMode warnMode>
-    class DynamicPreparedStatement : public detail::PreparedStatementBase<storeResult, validateMode, warnMode>
+    template<bool storeResult, ValidateMetadataMode validateMode, ValidateMetadataMode warnMode, bool ignoreNullable>
+    class DynamicPreparedStatement : public detail::PreparedStatementBase<storeResult, validateMode, warnMode, ignoreNullable>
     {
     private:
         unsigned int paramsCount = 0;
@@ -55,7 +55,7 @@ namespace SuperiorMySqlpp
 
     public:
         DynamicPreparedStatement(LowLevel::DBDriver& driver, const std::string& query)
-            : detail::PreparedStatementBase<storeResult, validateMode, warnMode>{driver.makeStatement()}
+            : detail::PreparedStatementBase<storeResult, validateMode, warnMode, ignoreNullable>{driver.makeStatement()}
         {
             this->statement.prepare(query);
 

--- a/include/superior_mysqlpp/dynamic_prepared_statement_fwd.hpp
+++ b/include/superior_mysqlpp/dynamic_prepared_statement_fwd.hpp
@@ -12,6 +12,7 @@ namespace SuperiorMySqlpp
 {
     template<bool storeResult=detail::PreparedStatementsDefault::getStoreResult(),
              ValidateMetadataMode validateMode=detail::PreparedStatementsDefault::getValidateMode(),
-             ValidateMetadataMode warnMode=detail::PreparedStatementsDefault::getWarnMode()>
+             ValidateMetadataMode warnMode=detail::PreparedStatementsDefault::getWarnMode(),
+             bool ignoreNullable=detail::PreparedStatementsDefault::getIgnoreNullable()>
     class DynamicPreparedStatement;
 }

--- a/include/superior_mysqlpp/prepared_statement.hpp
+++ b/include/superior_mysqlpp/prepared_statement.hpp
@@ -72,8 +72,8 @@ namespace SuperiorMySqlpp
     using ResultBindings = Bindings<false, Types...>;
 
 
-    template<typename ResultBindings, typename ParamBindings, bool storeResult, ValidateMetadataMode validateMode, ValidateMetadataMode warnMode>
-    class PreparedStatement : public detail::PreparedStatementBase<storeResult, validateMode, warnMode>
+    template<typename ResultBindings, typename ParamBindings, bool storeResult, ValidateMetadataMode validateMode, ValidateMetadataMode warnMode, bool ignoreNullable>
+    class PreparedStatement : public detail::PreparedStatementBase<storeResult, validateMode, warnMode, ignoreNullable>
     {
     private:
         ResultBindings resultBindings;
@@ -93,7 +93,7 @@ namespace SuperiorMySqlpp
                           std::index_sequence<RI...>,
                           ParamArgsTuple&& paramArgsTuple,
                           std::index_sequence<PI...>)
-            : detail::PreparedStatementBase<storeResult, validateMode, warnMode>{driver.makeStatement()},
+            : detail::PreparedStatementBase<storeResult, validateMode, warnMode, ignoreNullable>{driver.makeStatement()},
               resultBindings{std::get<RI>(std::forward<ResultArgsTuple>(resultArgsTuple))...},
               paramsBindings{std::get<PI>(std::forward<ParamArgsTuple>(paramArgsTuple))...}
         {

--- a/include/superior_mysqlpp/prepared_statement_fwd.hpp
+++ b/include/superior_mysqlpp/prepared_statement_fwd.hpp
@@ -38,6 +38,11 @@ namespace SuperiorMySqlpp
                 return ValidateMetadataMode::Same;
             }
 
+            /**
+             * Returns default value for prepared statement flag ignoreNullable.
+             * Usually nullable should not be ignored.
+             * @return always false
+             */
             constexpr auto getIgnoreNullable()
             {
                 return false;

--- a/include/superior_mysqlpp/prepared_statement_fwd.hpp
+++ b/include/superior_mysqlpp/prepared_statement_fwd.hpp
@@ -37,13 +37,19 @@ namespace SuperiorMySqlpp
             {
                 return ValidateMetadataMode::Same;
             }
+
+            constexpr auto getIgnoreNullable()
+            {
+                return false;
+            }
         }
     }
 
     template<typename ResultBindings, typename ParamBindings,
              bool storeResult=detail::PreparedStatementsDefault::getStoreResult(),
              ValidateMetadataMode validateMode=detail::PreparedStatementsDefault::getValidateMode(),
-             ValidateMetadataMode warnMode=detail::PreparedStatementsDefault::getWarnMode()>
+             ValidateMetadataMode warnMode=detail::PreparedStatementsDefault::getWarnMode(),
+             bool ignoreNullable=detail::PreparedStatementsDefault::getIgnoreNullable()>
     class PreparedStatement;
 }
 

--- a/include/superior_mysqlpp/prepared_statements/prepared_statement_base.hpp
+++ b/include/superior_mysqlpp/prepared_statements/prepared_statement_base.hpp
@@ -92,7 +92,7 @@ namespace SuperiorMySqlpp
         };
 
 
-        template<bool storeResult, ValidateMetadataMode validateMode, ValidateMetadataMode warnMode>
+        template<bool storeResult, ValidateMetadataMode validateMode, ValidateMetadataMode warnMode, bool ignoreNullable>
         class PreparedStatementBase : public StoreOrUseResultBase<storeResult>//, public ValidateResult<validateMetadataMode>
         {
         protected:
@@ -276,7 +276,7 @@ namespace SuperiorMySqlpp
                     }
 
                     // We cannot read nullable value into non-nullable one
-                    if (resultMetadata.isNullable() && binding.is_null == nullptr)
+                    if (resultMetadata.isNullable() && binding.is_null == nullptr && !ignoreNullable)
                     {
                         if (validateMode != ValidateMetadataMode::Disabled)
                         {

--- a/include/superior_mysqlpp/prepared_statements/prepared_statement_base.hpp
+++ b/include/superior_mysqlpp/prepared_statements/prepared_statement_base.hpp
@@ -92,6 +92,31 @@ namespace SuperiorMySqlpp
         };
 
 
+        /**
+         * Base class for prepared statements.
+         * Contains mostly low level methods communicating directly with underlying mysql C library.
+         * Also takes care for prepared statement's argument validation according to PreparedStatement settings.
+         *
+         * Settings itself are templated, so for different settings, different classes will be created.
+         *
+         * @tparam storeResult    flag - when true, mysql store result is used
+         * @tparam validateMode   enum - says how params or results will be validated (more in {@link ValidateMetadataMode}).
+         *                        When params or results doesn't comply with rules set by this option, exception will
+         *                        be thrown.
+         * @tparam warnMode       enum - says when user will be warned. These is same enum as {@param validateMode}.
+         *                        When params or results doesn't comply with rules set by this option a debug message
+         *                        will be issued with description, which rule was broken.
+         * @tparam ignoreNullable flag - says if {@link #validateResultMetadata()) ignores null value.
+         *                        (Feasible only for prepare statement results.)
+         *                        In mysql every data type can be also set to null. In C++ this is not the case.
+         *                        At least not for primitive types. Usually when we read data from mysql, we also need
+         *                        to set some "null" flag. In this library we can easily do it by mapping mysql data
+         *                        type to Nullable<T> type, which is simple wrapper (for any data type), that can store
+         *                        this "null flag". During result validation, this is also one of the checks - if we are
+         *                        able to store this "null flag". Sometimes however we just want to ignore null flag
+         *                        (result can then contain unspecified data, but we don't care), that is what this flag
+         *                        is for.
+         */
         template<bool storeResult, ValidateMetadataMode validateMode, ValidateMetadataMode warnMode, bool ignoreNullable>
         class PreparedStatementBase : public StoreOrUseResultBase<storeResult>//, public ValidateResult<validateMetadataMode>
         {
@@ -275,7 +300,11 @@ namespace SuperiorMySqlpp
                         );
                     }
 
-                    // We cannot read nullable value into non-nullable one
+                    // We usually don't want to read nullable value into non-nullable one
+                    // However it is possible, because mysql doesn't need to write this flag, to user provided place
+                    // (see in mysql_stmt_bind_result(...) definition in file "libmysql.c".
+                    // In this case however the result value is not set. We only ignore possible null value and we do
+                    // it only when we explicitly want to.
                     if (resultMetadata.isNullable() && binding.is_null == nullptr && !ignoreNullable)
                     {
                         if (validateMode != ValidateMetadataMode::Disabled)

--- a/include/superior_mysqlpp/prepared_statements/prepared_statement_base.hpp
+++ b/include/superior_mysqlpp/prepared_statements/prepared_statement_base.hpp
@@ -114,7 +114,7 @@ namespace SuperiorMySqlpp
          *                        type to Nullable<T> type, which is simple wrapper (for any data type), that can store
          *                        this "null flag". During result validation, this is also one of the checks - if we are
          *                        able to store this "null flag". Sometimes however we just want to ignore null flag
-         *                        (result can then contain unspecified data, but we don't care), that is what this flag
+         *                        (binded result memory then will be not set, where null was sent), that is what this flag
          *                        is for.
          */
         template<bool storeResult, ValidateMetadataMode validateMode, ValidateMetadataMode warnMode, bool ignoreNullable>

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -1,6 +1,9 @@
 libsuperiormysqlpp (0.2.2) UNRELEASED; urgency=medium
 
-  *
+  * Add optional settings for prepared statements "ignoreNullable", that
+    when set, will not require Nullable<T> value for result. Null value
+    will be ignored and result data will be not set, when set null value is sent from
+    database.
 
  -- Daniel Pernis <daniel.pernis@firma.seznam.cz>  Fri, 29 Jul 2016 11:20:07 +0200
 


### PR DESCRIPTION
Prepared statements can ignore nullable values on result, when requested to do so(optional settings in template parameters).
Ignore nullable values means, that "null flag" will not be set in result, and binded value is not written, when it is null.