### PR TITLE
Clang compile fixes

### DIFF
--- a/include/superior_mysqlpp/converters/to_integer.hpp
+++ b/include/superior_mysqlpp/converters/to_integer.hpp
@@ -6,7 +6,6 @@
 
 
 #include <cinttypes>
-#include <cmath>
 #include <utility>
 #include <limits>
 #include <stdexcept>
@@ -16,13 +15,18 @@ namespace SuperiorMySqlpp { namespace Converters
 {
     namespace detail
     {
+        template <class T>
+        inline constexpr T pow(T const& x, std::size_t n) {
+            return n > 0 ? x * pow(x, n - 1) : 1;
+        }
+
         template<typename T, int length, bool validate>
         struct ToIntegerParserImpl
         {
             static_assert(std::numeric_limits<T>::digits10, "length > digits10");
             static inline void call(T& result, const char*& str) noexcept(validate)
             {
-                static constexpr T base = std::pow(10, length-1);
+                static constexpr T base = pow(10, length-1);
                 char c = *str;
                 if (validate)
                 {

--- a/include/superior_mysqlpp/field.hpp
+++ b/include/superior_mysqlpp/field.hpp
@@ -53,7 +53,7 @@ namespace SuperiorMySqlpp
             return stringData;
         }
 
-        const auto cbegin() const noexcept
+        auto cbegin() const noexcept
         {
             return begin();
         }
@@ -63,7 +63,7 @@ namespace SuperiorMySqlpp
             return stringData + stringLength;
         }
 
-        const auto cend() const noexcept
+        auto cend() const noexcept
         {
             return end();
         }

--- a/include/superior_mysqlpp/iterator.hpp
+++ b/include/superior_mysqlpp/iterator.hpp
@@ -20,7 +20,7 @@ namespace SuperiorMySqlpp { namespace detail
 
     public:
         template<typename... Args>
-        Iterator(Pointer pointer, Args... args)
+        Iterator(Pointer pointer, Args...)
             : pointer{pointer}
         {
         }

--- a/include/superior_mysqlpp/logging.hpp
+++ b/include/superior_mysqlpp/logging.hpp
@@ -226,9 +226,9 @@ namespace SuperiorMySqlpp {
             virtual void logMySqlClose(std::uint_fast64_t /*connectionId*/) const noexcept override {}
             virtual void logMySqlPing(std::uint_fast64_t /*connectionId*/) const noexcept override {}
             virtual void logMySqlQuery(std::uint_fast64_t /*connectionId*/, const StringView& /*query*/) const noexcept override {}
-            virtual void logMySqlStartTransaction(std::uint_fast64_t /*connectionId*/) const noexcept {};
-            virtual void logMySqlCommitTransaction(std::uint_fast64_t /*connectionId*/) const noexcept {};
-            virtual void logMySqlRollbackTransaction(std::uint_fast64_t /*connectionId*/) const noexcept {};
+            virtual void logMySqlStartTransaction(std::uint_fast64_t /*connectionId*/) const noexcept override {};
+            virtual void logMySqlCommitTransaction(std::uint_fast64_t /*connectionId*/) const noexcept override {};
+            virtual void logMySqlRollbackTransaction(std::uint_fast64_t /*connectionId*/) const noexcept override {};
             virtual void logMySqlStmtPrepare(std::uint_fast64_t /*connectionId*/, std::uint_fast64_t /*id*/, const StringView& /*query*/) const noexcept override {}
             virtual void logMySqlStmtExecute(std::uint_fast64_t /*connectionId*/, std::uint_fast64_t /*id*/) const noexcept override {}
             virtual void logMySqlStmtMetadataWarning(
@@ -283,7 +283,7 @@ namespace SuperiorMySqlpp {
                     std::uint_fast64_t connectionId,
                     std::uint_fast64_t id,
                     std::size_t index
-            ) const noexcept
+            ) const noexcept override
             {
                 std::cerr << stringify("Connection [", connectionId, "]: PS [", id, "]: ")
                     << "Result types at index " << index << " don't match!\n"

--- a/include/superior_mysqlpp/master_slave_connection_pools.hpp
+++ b/include/superior_mysqlpp/master_slave_connection_pools.hpp
@@ -252,7 +252,7 @@ namespace SuperiorMySqlpp
             );
         }
 
-        const auto cbegin() const
+        auto cbegin() const
         {
             return makeConcatIterator(
                     &master, &master+1,
@@ -261,7 +261,7 @@ namespace SuperiorMySqlpp
             );
         }
 
-        const auto cend() const
+        auto cend() const
         {
             return makeConcatIterator(
                     &master, &master+1,
@@ -270,12 +270,12 @@ namespace SuperiorMySqlpp
             );
         }
 
-        const auto begin() const
+        auto begin() const
         {
             return cbegin();
         }
 
-        const auto end() const
+        auto end() const
         {
             return cend();
         }
@@ -309,22 +309,22 @@ namespace SuperiorMySqlpp
                 return makeSpecialIterator(parent.slaves.end(), mapSecondGetter);
             }
 
-            const auto cbegin() const
+            auto cbegin() const
             {
                 return makeSpecialIterator(parent.slaves.cbegin(), mapSecondGetter);
             }
 
-            const auto cend() const
+            auto cend() const
             {
                 return makeSpecialIterator(parent.slaves.cend(), mapSecondGetter);
             }
 
-            const auto begin() const
+            auto begin() const
             {
                 return cbegin();
             }
 
-            const auto end() const
+            auto end() const
             {
                 return cend();
             }

--- a/include/superior_mysqlpp/row.hpp
+++ b/include/superior_mysqlpp/row.hpp
@@ -68,7 +68,7 @@ namespace SuperiorMySqlpp
             return {mysqlRow, *this};
         }
 
-        const auto cbegin() const noexcept
+        auto cbegin() const noexcept
         {
             return begin();
         }
@@ -78,7 +78,7 @@ namespace SuperiorMySqlpp
             return {mysqlRow + fieldsCount, *this};
         }
 
-        const auto cend() const noexcept
+        auto cend() const noexcept
         {
             return end();
         }

--- a/include/superior_mysqlpp/types/array.hpp
+++ b/include/superior_mysqlpp/types/array.hpp
@@ -76,12 +76,12 @@ namespace SuperiorMySqlpp
             return array.begin();
         }
 
-        const auto begin() const
+        auto begin() const
         {
             return array.begin();
         }
 
-        const auto cbegin() const
+        auto cbegin() const
         {
             return array.cbegin();
         }
@@ -91,12 +91,12 @@ namespace SuperiorMySqlpp
             return begin() + count();
         }
 
-        const auto end() const
+        auto end() const
         {
             return cbegin() + count();
         }
 
-        const auto cend() const
+        auto cend() const
         {
             return cbegin() + count();
         }
@@ -106,12 +106,12 @@ namespace SuperiorMySqlpp
             return array.end();
         }
 
-        const auto endOfStorage() const
+        auto endOfStorage() const
         {
             return array.end();
         }
 
-        const auto cendOfStorage() const
+        auto cendOfStorage() const
         {
             return array.cend();
         }
@@ -121,7 +121,7 @@ namespace SuperiorMySqlpp
             return array.data();
         }
 
-        constexpr const auto data() const
+        constexpr auto data() const
         {
             return array.data();
         }

--- a/tests/db_access/connection_pool.cpp
+++ b/tests/db_access/connection_pool.cpp
@@ -31,7 +31,6 @@ go_bandit([](){
     using namespace std::chrono_literals;
 
     describe("Test connection pool", [&](){
-        auto additionalTimeout = 10ms;
         auto& s = getSettingsRef();
 
         it("can clear pool properly", [&](){
@@ -51,6 +50,7 @@ go_bandit([](){
 
             {
                 auto&& item = connectionPool.get();
+                static_cast<void>(item);
                 poolState = connectionPool.poolState();
                 AssertThat(poolState.size, Equals(1U));
                 AssertThat(poolState.available, Equals(0U));
@@ -77,6 +77,8 @@ go_bandit([](){
             {
                 auto&& item1 = connectionPool.get();
                 auto&& item2 = connectionPool.get();
+                static_cast<void>(item1);
+                static_cast<void>(item2);
                 poolState = connectionPool.poolState();
                 AssertThat(poolState.size, Equals(2U));
                 AssertThat(poolState.available, Equals(0U));
@@ -144,7 +146,6 @@ go_bandit([](){
             auto connectionPool = makeConnectionPool([&](){
                 return std::async(std::launch::async, [&](){ return std::make_shared<Connection>(s.database, s.user, s.password, s.host, s.port); });
             });
-            auto reasonableTimeout = connectionPool.getResourceCountKeeperSleepTime() + additionalTimeout;
 
             connectionPool.setMinSpare(10);
             connectionPool.setMaxSpare(20);
@@ -206,7 +207,6 @@ go_bandit([](){
 
         it("has working keeper job", [&](){
             auto connectionPool = makeConnectionPool(makeSharedPtrConnection);
-            auto reasonableTimeout = connectionPool.getResourceCountKeeperSleepTime() + additionalTimeout;
 
             connectionPool.setMinSpare(1);
             connectionPool.setMaxSpare(2);

--- a/tests/db_access/master_slave_connection_pools.cpp
+++ b/tests/db_access/master_slave_connection_pools.cpp
@@ -42,7 +42,7 @@ int count(const T& collection)
 }
 
 
-auto MySqlFactoryLambda = [&](){
+auto MySqlFactoryLambda = [](){
     return std::async(std::launch::async, [&](){
         return std::make_shared<SuperiorMySqlpp::Connection>(
         "databaseName",
@@ -57,7 +57,7 @@ class MySqlFactory
 {
 public:
     template<typename... Args>
-    MySqlFactory(Args&&... args)
+    MySqlFactory(Args&&...)
     {}
 
     MySqlFactory(const MySqlFactory&) = default;
@@ -72,7 +72,6 @@ public:
 
 go_bandit([](){
     describe("Test ms connection pools", [&](){
-        auto additionalTimeout = 10ms;
         auto& s = getSettingsRef();
 
         it("will instantiate", [&](){

--- a/tests/makefile
+++ b/tests/makefile
@@ -11,11 +11,21 @@ Q :=@
 program :=tester
 odr :=odr_program
 
-CXX :=g++
+CXX ?=g++
+
+HAVE_CLANG := 0
+ifeq ($(shell $(CC) -v 2>&1 | grep -c "clang version"), 1)
+    HAVE_CLANG := 1
+endif
 
 CXXFLAGS += -std=c++14
 CXXFLAGS += -pedantic-errors
-CXXFLAGS += -Wall -Wextra -Wswitch-enum -Wnarrowing -Wabi-tag
+CXXFLAGS += -Wall -Wextra -Wswitch-enum -Wnarrowing
+ifneq ($(HAVE_CLANG),1)
+    CXXFLAGS += -Wabi-tag
+else
+    CXXFLAGS += -DHAVE_CLANG
+endif
 CXXFLAGS += -Werror
 CXXFLAGS += -fPIC
 CXXFLAGS += -fsanitize=address

--- a/tests/types/concat_iterator.cpp
+++ b/tests/types/concat_iterator.cpp
@@ -16,8 +16,10 @@ using namespace std::string_literals;
 
 
 
+#ifndef HAVE_CLANG
 #pragma GCC push_options
 #pragma GCC optimize ("O0")
+#endif
 go_bandit([](){
     describe("Test ConcatIterator", [&](){
         it("can work on empty vectors", [&](){
@@ -161,4 +163,6 @@ go_bandit([](){
         });
     });
 });
+#ifndef HAVE_CLANG
 #pragma GCC pop_options
+#endif


### PR DESCRIPTION
Most of the fixes are removing `const` but there is one fix to note: adding constexpr pow() function, see `to_integer.hpp`.