### PR TITLE
Fix ostream operator for null values in Row

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Please help us out by reporting bugs. (https://github.com/seznam/SuperiorMySqlpp
 We appreciate your feedback!
 
 # Preview
-Until we create proper examples, you can see all functionality in action by looking at out tests (https://github.com/seznam/SuperiorMySqlpp/tree/master/tests).
+Until we create proper examples, you can see all functionality in action by looking at our tests (https://github.com/seznam/SuperiorMySqlpp/tree/master/tests).
 Please be aware that tests must validate all possible cases and syntax and should not be taken as reference in these matters.
 
 You can look at some basic examples below:
@@ -151,7 +151,7 @@ while (auto row = result.fetchRow())
 To escape variable manually you may use method connection.escapeString. Preferred way is using query stream manipulators:
 ```c++
 auto query = connection.makeQuery();
-query << escape << "ab'cd";  // escape - next argument will be escaped 
+query << escape << "ab'cd";  // escape - next argument will be escaped
 
 ```
 
@@ -198,7 +198,7 @@ while (preparedStatement.fetch())
     Sql::Int id, money;
     std::tie(id, money) = preparedStatement.getResult();
 
-    // or directly use e.g. id as: 
+    // or directly use e.g. id as:
     preparedStatement.getResult().get<0>()
 }
 ```
@@ -280,15 +280,15 @@ class MyLogger final : public Loggers::Base
 {
     using Base::Base;
     virtual ~MyLogger() override
-    { 
-        // do something 
+    {
+        // do something
     }
 
     virtual void logWarning(const std::string& message) const override
     {
-        // do something 
+        // do something
     }
-    
+
     // a lot of logging methods like: logMySqlConnecting, logMySqlConnected, logMySqlClose, logMySqlCommit, ...
 }
 

--- a/db/test_database.sql
+++ b/db/test_database.sql
@@ -122,3 +122,13 @@ CREATE TABLE `nullable` (
     `nullable_id` INT(11),
     `nullable_name` VARCHAR(50) NULL
 )  ENGINE=INNODB DEFAULT CHARSET=UTF8;
+
+DROP TABLE IF EXISTS `row`;
+CREATE TABLE `row` (
+    `id` INT(11) NOT NULL,
+    `nullable_value` VARCHAR(100) NULL
+)  ENGINE=INNODB DEFAULT CHARSET=UTF8;
+INSERT INTO `row`(
+    `id`,
+    `nullable_value`)
+VALUES (1, 'value'), (2, NULL);

--- a/include/superior_mysqlpp/row.hpp
+++ b/include/superior_mysqlpp/row.hpp
@@ -104,12 +104,12 @@ namespace SuperiorMySqlpp
         {
             if (first)
             {
-                os << item;
+                os << item.getStringView();
                 first = false;
             }
             else
             {
-                os << ", " << item;
+                os << ", " << item.getStringView();
             }
         }
         os << "]";

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -1,6 +1,7 @@
 libsuperiormysqlpp (0.3.1) UNRELEASED; urgency=medium
 
-  *
+  [ Radek Smejdir ]
+  * Fix ostream operator for null values in Row
 
  -- Daniel Pernis <daniel.pernis@firma.seznam.cz>  Thu, 06 Apr 2017 16:44:52 +0200
 

--- a/tests/db_access/row.cpp
+++ b/tests/db_access/row.cpp
@@ -1,0 +1,44 @@
+/*
+ * Author: Radek Smejdir
+ */
+
+#include <bandit/bandit.h>
+#include <sstream>
+
+#include <superior_mysqlpp.hpp>
+
+#include "settings.hpp"
+
+using namespace bandit;
+using namespace SuperiorMySqlpp;
+
+go_bandit([](){
+    describe("Test Row", [&](){
+        auto& s = getSettingsRef();
+        auto connection = std::make_shared<Connection>(s.database, s.user, s.password, s.host, s.port);
+        
+        it("can print nonnull data into stream", [&](){
+            auto query = connection->makeQuery("SELECT * FROM `test_superior_sqlpp`.`row` WHERE `id`=1");
+            query.execute();
+            auto result = query.store();
+            
+            std::ostringstream out;
+            out << result.fetchRow();
+            
+            AssertThat(result.getRowsCount(), Equals(1u));
+            AssertThat(out.str(), Equals("[1, value]"));
+        });
+        
+        it("can print data containing null value into stream", [&](){
+            auto query = connection->makeQuery("SELECT * FROM `test_superior_sqlpp`.`row` WHERE `id`=2");
+            query.execute();
+            auto result = query.store();
+            
+            std::ostringstream out;
+            out << result.fetchRow();
+            
+            AssertThat(result.getRowsCount(), Equals(1u));
+            AssertThat(out.str(), Equals("[2, ]"));
+        });
+    });
+});

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -35,7 +35,7 @@ public:
 
 void printUsage()
 {
-    std::cerr << "Usage: ./tester <MySqlIpAddress> <MySqlPort> [bandit-options...]" << std::endl;
+    std::cerr << "Usage: ./tester <MySqlIpAddress> <MySqlPort> <MySqlContainerId> [bandit-options...]" << std::endl;
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
It fixes #32. Reported issue was simulated on null values in table.
Some typos and some other details like space chars at end of lines were fixed in separate commit.