### PR TITLE
Fix ostream operator for null values in Row

### DIFF
--- a/db/test_database.sql
+++ b/db/test_database.sql
@@ -122,3 +122,13 @@ CREATE TABLE `nullable` (
     `nullable_id` INT(11),
     `nullable_name` VARCHAR(50) NULL
 )  ENGINE=INNODB DEFAULT CHARSET=UTF8;
+
+DROP TABLE IF EXISTS `row`;
+CREATE TABLE `row` (
+    `id` INT(11) NOT NULL,
+    `nullable_value` VARCHAR(100) NULL
+)  ENGINE=INNODB DEFAULT CHARSET=UTF8;
+INSERT INTO `row`(
+    `id`,
+    `nullable_value`)
+VALUES (1, 'value'), (2, NULL);

--- a/include/superior_mysqlpp/row.hpp
+++ b/include/superior_mysqlpp/row.hpp
@@ -104,12 +104,12 @@ namespace SuperiorMySqlpp
         {
             if (first)
             {
-                os << item;
+                os << item.getStringView();
                 first = false;
             }
             else
             {
-                os << ", " << item;
+                os << ", " << item.getStringView();
             }
         }
         os << "]";

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -1,6 +1,7 @@
 libsuperiormysqlpp (0.3.1) UNRELEASED; urgency=medium
 
-  *
+  [ Radek Smejdir ]
+  * Fix ostream operator for null values in Row
 
  -- Daniel Pernis <daniel.pernis@firma.seznam.cz>  Thu, 06 Apr 2017 16:44:52 +0200
 

--- a/tests/db_access/row.cpp
+++ b/tests/db_access/row.cpp
@@ -1,0 +1,44 @@
+/*
+ * Author: Radek Smejdir
+ */
+
+#include <bandit/bandit.h>
+#include <sstream>
+
+#include <superior_mysqlpp.hpp>
+
+#include "settings.hpp"
+
+using namespace bandit;
+using namespace SuperiorMySqlpp;
+
+go_bandit([](){
+    describe("Test Row", [&](){
+        auto& s = getSettingsRef();
+        auto connection = std::make_shared<Connection>(s.database, s.user, s.password, s.host, s.port);
+
+        it("can print nonnull data into stream", [&](){
+            auto query = connection->makeQuery("SELECT * FROM `test_superior_sqlpp`.`row` WHERE `id`=1");
+            query.execute();
+            auto result = query.store();
+
+            std::ostringstream out;
+            out << result.fetchRow();
+
+            AssertThat(result.getRowsCount(), Equals(1u));
+            AssertThat(out.str(), Equals("[1, value]"));
+        });
+
+        it("can print data containing null value into stream", [&](){
+            auto query = connection->makeQuery("SELECT * FROM `test_superior_sqlpp`.`row` WHERE `id`=2");
+            query.execute();
+            auto result = query.store();
+
+            std::ostringstream out;
+            out << result.fetchRow();
+
+            AssertThat(result.getRowsCount(), Equals(1u));
+            AssertThat(out.str(), Equals("[2, ]"));
+        });
+    });
+});


### PR DESCRIPTION
It fixes #32. Reported issue was tested on null values in table.