### PR TITLE
Testcase for wrong initialization of Nullable<String> in dynamic resu…

### DIFF
--- a/tests/db_access/dynamic_prepared_statements.cpp
+++ b/tests/db_access/dynamic_prepared_statements.cpp
@@ -148,6 +148,7 @@ go_bandit([](){
             int count = 0;
             while (preparedStatement.fetch())
             {
+                AssertThat(sname.isValid(), IsTrue());
                 auto name = sname->getString();
 
                 AssertThat(id, Equals(12));


### PR DESCRIPTION
Added testcase from @tnozicka for wrong Nullable<String> initialization in dynamic result binding. This test proves the issue #10 is already fixed.