### PR TITLE
Validation of uninitialized result binds

### DIFF
--- a/include/superior_mysqlpp/exceptions.hpp
+++ b/include/superior_mysqlpp/exceptions.hpp
@@ -77,6 +77,12 @@ namespace SuperiorMySqlpp
         using SuperiorMySqlppError::SuperiorMySqlppError;
     };
 
+    class PreparedStatementBindError : public SuperiorMySqlppError
+    {
+    public:
+        using SuperiorMySqlppError::SuperiorMySqlppError;
+    };
+
     class DynamicPreparedStatementTypeError : public SuperiorMySqlppError
     {
     public:

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -1,6 +1,7 @@
 libsuperiormysqlpp (0.3.2) UNRELEASED; urgency=medium
 
-  *
+  [ Radek Smejdir ]
+  * Add uninitialized result binds validation
 
  -- Michal Fizek <michal.fizek@firma.seznam.cz>  Wed, 14 Feb 2018 08:24:25 +0100
 

--- a/tests/db_access/dynamic_prepared_statements.cpp
+++ b/tests/db_access/dynamic_prepared_statements.cpp
@@ -279,7 +279,7 @@ go_bandit([](){
             int id;
             preparedStatement.bindResult(0, id);
 
-            preparedStatement.updateResultBindings();
+            AssertThrows(PreparedStatementBindError, preparedStatement.updateResultBindings());
         });
     });
 });

--- a/tests/db_access/dynamic_prepared_statements.cpp
+++ b/tests/db_access/dynamic_prepared_statements.cpp
@@ -268,7 +268,18 @@ go_bandit([](){
                 AssertThat(nullable_name.value(), Equals(name));
             }
         });
+
+        it("can validate that all results are binded", [&](){
+            auto preparedStatement = connection.makeDynamicPreparedStatement(
+                "SELECT `id`,`uid` FROM `test_superior_sqlpp`.`xuser_datatypes`"
+            );
+
+            preparedStatement.execute();
+
+            int id;
+            preparedStatement.bindResult(0, id);
+
+            preparedStatement.updateResultBindings();
+        });
     });
 });
-
-


### PR DESCRIPTION
It fixes #14 - Results which are not binded are checked as a first step of validation. Exception `PreparedStatementBindError` is thrown when some result is not initialized.