### PR TITLE
Remove redundant zeroing memsets

### DIFF
--- a/include/superior_mysqlpp/dynamic_prepared_statement.hpp
+++ b/include/superior_mysqlpp/dynamic_prepared_statement.hpp
@@ -63,7 +63,6 @@ namespace SuperiorMySqlpp
             if (paramsCount > 0)
             {
                 paramsBindings.resize(paramsCount);
-                std::memset(paramsBindings.data(), 0, sizeof(paramsBindings));
             }
         }
 
@@ -142,7 +141,6 @@ namespace SuperiorMySqlpp
             if (resultFieldCount > 0)
             {
                 resultBindings.resize(resultFieldCount);
-                std::memset(resultBindings.data(), 0, sizeof(resultBindings));
             }
 
             this->storeOrUse();

--- a/include/superior_mysqlpp/prepared_statement.hpp
+++ b/include/superior_mysqlpp/prepared_statement.hpp
@@ -40,16 +40,13 @@ namespace SuperiorMySqlpp
 
 
     public:
+        /* Note: using just 'bindings{}' triggers (premature) warning in GCC 4.9.2,
+         * see discussion at https://stackoverflow.com/questions/31271975/why-can-i-initialize-a-regular-array-from-but-not-a-stdarray */
         template<typename... Args>
         Bindings(Args&&... args)
-            : data{std::forward<Args>(args)...}
+            : data{std::forward<Args>(args)...}, bindings{{}}
         {
             static_assert(sizeof...(Args) == 0 || sizeof...(Args) == sizeof...(Types), "You shall initialize all bindings data or none of them!");
-            if (bindings.size() > 0)
-            {
-                std::memset(bindings.data(), 0, sizeof(bindings));
-            }
-
             update();
         }
 

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -5,6 +5,7 @@ libsuperiormysqlpp (0.3.1) UNRELEASED; urgency=medium
 
   [ Peter Opatril ]
   * Fix incorrect Clang detection in test makefile
+  * Removed redundant zeroing memsets for std::vector, memsets for std::array made redundant by the use of initializer
 
  -- Daniel Pernis <daniel.pernis@firma.seznam.cz>  Thu, 06 Apr 2017 16:44:52 +0200
 


### PR DESCRIPTION
Fixes issue #38.
Removes redundant zeroing memsets - for std::vector. Also, memsets for std::array made redundant by the use of initializer.