### PR TITLE
Fix incorrect Clang detection in test makefile 

### DIFF
--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -3,6 +3,9 @@ libsuperiormysqlpp (0.3.1) UNRELEASED; urgency=medium
   [ Radek Smejdir ]
   * Fix ostream operator for null values in Row
 
+  [ Peter Opatril ]
+  * Fix incorrect Clang detection in test makefile
+
  -- Daniel Pernis <daniel.pernis@firma.seznam.cz>  Thu, 06 Apr 2017 16:44:52 +0200
 
 libsuperiormysqlpp (0.3.0) unstable; urgency=medium

--- a/tests/makefile
+++ b/tests/makefile
@@ -14,7 +14,7 @@ odr :=odr_program
 CXX ?=g++
 
 HAVE_CLANG := 0
-ifeq ($(shell $(CC) -v 2>&1 | grep -c "clang version"), 1)
+ifeq ($(shell $(CXX) -v 2>&1 | grep -c "clang version"), 1)
     HAVE_CLANG := 1
 endif
 


### PR DESCRIPTION
Despite using C++ compiler for everything, detection of Clang was incorrectly using CC instead of CXX variable.