### PR TITLE
Remove -Wabi-tag from CXXFLAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,3 +298,16 @@ DefaultLogger::setLoggerPtr(std::move(logger));
 
 # Current issues
 There are problems caused by MySQL C API's bad design which are solved by https://github.com/seznam/SuperiorMySqlpp/blob/master/include/superior_mysqlpp/low_level/mysql_hacks.hpp. This is causing problems with MariaDB which stripped down some symbols from their shared object that we use to fix this bug. (https://github.com/seznam/SuperiorMySqlpp/issues/2)
+
+## ABI tag warnings
+GCC supports `-Wabi-tag` that should warn when a type with ABI tag is used in context that not have that ABI tag. This warning should be used only for building shared libraries.
+Mentioned compiler warning informs about situations where library may be theoretically successfully linked with another one built with incompatible ABI. For more info on this topic, see
+ - https://developers.redhat.com/blog/2015/02/05/gcc5-and-the-c11-abi/
+ - https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
+
+This warning is triggered many times in this library, for example for each function where `std::string` is returned from the function or for each structure that contains `std::string` -- generally, in each case where the type is not part of the resulting mangled name for given symbol.
+Unfortunately, the only way to resolve this warning properly is explicitly put `abi_tag` attribute to every single affected symbol, which seems excessive and does not help readability.
+ABI tag incompatibility is transitive to descendants -- that means when you build own library using *SuperiorMySqlpp* you shouldn't use `-Wabi-tag` either.
+
+Notably, our internet research seem to suggest that this issue (linking code built with old and new ABI) is almost never occurring in practice, as all packages for given OS are by convention built with the same version.
+Judging from the relative lack of related problems, tutorials or general discussion about this topic, `-Wabi-tag` seems to be generally unused by now.

--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ DefaultLogger::setLoggerPtr(std::move(logger));
 There are problems caused by MySQL C API's bad design which are solved by https://github.com/seznam/SuperiorMySqlpp/blob/master/include/superior_mysqlpp/low_level/mysql_hacks.hpp. This is causing problems with MariaDB which stripped down some symbols from their shared object that we use to fix this bug. (https://github.com/seznam/SuperiorMySqlpp/issues/2)
 
 ## ABI tag warnings
-GCC supports `-Wabi-tag` that should warn when a type with ABI tag is used in context that not have that ABI tag. This warning should be used only for building shared libraries.
+GCC supports `-Wabi-tag` that should warn when a type with ABI tag is used in context that not have that ABI tag (https://gcc.gnu.org/onlinedocs/gcc-6.4.0/gcc/C_002b_002b-Dialect-Options.html#C_002b_002b-Dialect-Options). This warning should be used only for building shared libraries.
+
 Mentioned compiler warning informs about situations where library may be theoretically successfully linked with another one built with incompatible ABI. For more info on this topic, see
  - https://developers.redhat.com/blog/2015/02/05/gcc5-and-the-c11-abi/
  - https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -4,6 +4,7 @@ libsuperiormysqlpp (0.3.1) UNRELEASED; urgency=medium
   * Fix ostream operator for null values in Row
   * noexcept Statement::close will not throw MysqlInternalError anymore,
     error message is logged and std::terminate is called instead
+  * Remove -Wabi-tag from CXXFLAGS, see README.md for more details
 
   [ Peter Opatril ]
   * Fix incorrect Clang detection in test makefile

--- a/tests/makefile
+++ b/tests/makefile
@@ -21,9 +21,7 @@ endif
 CXXFLAGS += -std=c++14
 CXXFLAGS += -pedantic-errors
 CXXFLAGS += -Wall -Wextra -Wswitch-enum -Wnarrowing
-ifneq ($(HAVE_CLANG),1)
-    CXXFLAGS += -Wabi-tag
-else
+ifeq ($(HAVE_CLANG),1)
     CXXFLAGS += -DHAVE_CLANG
 endif
 CXXFLAGS += -Werror


### PR DESCRIPTION
Mentioned GCC warning informs about situations where library may be
theoretically successfully linked with another one built with
incompatible ABI. For more info on this topic, see
https://developers.redhat.com/blog/2015/02/05/gcc5-and-the-c11-abi/)
https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
Unfortunately, the only way to make this warning disappear is explicitly
put explicit abi_tag attribute to every single affected symbol, which
seems excessive and does not help readibility.
Notably, our internet research seem to suggest that this issue (linking
code built with old and new ABI) is almost never occuring in practice,
as all packages for given OS are by convention built with the same
version.
Judging from the relative lack of related problems, tutorials or general
discussion about this topic, -Wabi-tag seem to be now generally unused
by everyone.

This fix is one step from many in process of porting package to
debian-stretch.