### PR TITLE
GCC 6.3 warning - throwing an exception from noexcept method

### DIFF
--- a/include/superior_mysqlpp/logging.hpp
+++ b/include/superior_mysqlpp/logging.hpp
@@ -56,7 +56,7 @@ namespace SuperiorMySqlpp {
          */
 
         /*
-         * You are to choose to derive either from class Interface or class Empty
+         * You are to choose to derive either from class Interface or class Base
          * so you shall either implement all logging functions or only those you want.
          */
 

--- a/include/superior_mysqlpp/logging.hpp
+++ b/include/superior_mysqlpp/logging.hpp
@@ -150,6 +150,7 @@ namespace SuperiorMySqlpp {
             virtual void logMySqlStmtMetadataNullableToNonNullableWarning(std::uint_fast64_t /*connectionId*/, std::uint_fast64_t /*id*/, std::size_t /*index*/) const noexcept = 0;
 
             virtual void logMySqlStmtClose(std::uint_fast64_t /*connectionId*/, std::uint_fast64_t /*id*/) const noexcept = 0;
+            virtual void logMySqlStmtCloseError(std::uint_fast64_t /*connectionId*/, std::uint_fast64_t /*id*/, const StringView& /*mysqlError*/) const noexcept = 0;
             virtual void logMySqlTransactionRollbackFailed(std::uint_fast64_t /*connectionId*/, std::exception&) const noexcept = 0;
             virtual void logMySqlTransactionRollbackFailed(std::uint_fast64_t /*connectionId*/) const noexcept = 0;
         };
@@ -244,6 +245,7 @@ namespace SuperiorMySqlpp {
             virtual void logMySqlStmtMetadataNullableToNonNullableWarning(std::uint_fast64_t /*connectionId*/, std::uint_fast64_t /*id*/, std::size_t /*index*/) const noexcept override {}
 
             virtual void logMySqlStmtClose(std::uint_fast64_t /*connectionId*/, std::uint_fast64_t /*id*/) const noexcept override {}
+            virtual void logMySqlStmtCloseError(std::uint_fast64_t /*connectionId*/, std::uint_fast64_t /*id*/, const StringView& /*mysqlError*/) const noexcept override {}
             virtual void logMySqlTransactionRollbackFailed(std::uint_fast64_t /*connectionId*/, std::exception&) const noexcept override {}
             virtual void logMySqlTransactionRollbackFailed(std::uint_fast64_t /*connectionId*/) const noexcept override {}
         };
@@ -395,6 +397,12 @@ namespace SuperiorMySqlpp {
             {
                 SpinGuard guard{lock};
                 std::cerr << stringify("Connection [", connectionId, "]: PS [", id, "]: Closing.\n") << std::flush;
+            }
+
+            virtual void logMySqlStmtCloseError(std::uint_fast64_t connectionId, std::uint_fast64_t id, const StringView& mysqlError) const noexcept override
+            {
+                SpinGuard guard{lock};
+                std::cerr << stringify("Connection [", connectionId, "]: PS [", id, "]: Closing statement failed with error:\n", mysqlError) << std::flush;
             }
 
             virtual void logMySqlTransactionRollbackFailed(std::uint_fast64_t connectionId, std::exception& e) const noexcept override

--- a/include/superior_mysqlpp/low_level/dbdriver.hpp
+++ b/include/superior_mysqlpp/low_level/dbdriver.hpp
@@ -631,10 +631,11 @@ namespace SuperiorMySqlpp { namespace LowLevel
                 if (statementPtr != nullptr)
                 {
                     loggerPtr->logMySqlStmtClose(driverId, id);
+                    MYSQL* mysql = statementPtr->mysql;
                     if (mysql_stmt_close(statementPtr))
                     {
-                        throw MysqlInternalError("Failed to close statement!",
-                            mysql_stmt_error(statementPtr), mysql_stmt_errno(statementPtr));
+                        loggerPtr->logMySqlStmtCloseError(driverId, id, StringView{mysql_error(mysql)});
+                        std::terminate();
                     }
                 }
             }

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -2,6 +2,8 @@ libsuperiormysqlpp (0.3.1) UNRELEASED; urgency=medium
 
   [ Radek Smejdir ]
   * Fix ostream operator for null values in Row
+  * noexcept Statement::close will not throw MysqlInternalError anymore,
+    error message is logged and std::terminate is called instead
 
  -- Daniel Pernis <daniel.pernis@firma.seznam.cz>  Thu, 06 Apr 2017 16:44:52 +0200
 


### PR DESCRIPTION
Error will be logged instead of throwing an exception from noexcept
method Statement::close() and program will be terminated by
calling std::terminate directly.
It's fixed because is not intended to throw messages directly from
methods with noexcept specifier and this is also checked by compilers
with -Wall option by default.

It fixes #41 also.

This is one step from many in process of porting package to debian-stretch.