### PR TITLE
 Replace `string_view::to_string` with string ctor 

### DIFF
--- a/include/superior_mysqlpp/query_result.hpp
+++ b/include/superior_mysqlpp/query_result.hpp
@@ -115,7 +115,7 @@ namespace SuperiorMySqlpp
                 }
                 else
                 {
-                    throw OutOfRange{"Column name \"" + columnName.to_string() + "\" not found!"};
+                    throw OutOfRange{"Column name \"" + std::string(columnName) + "\" not found!"};
                 }
             }
 

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -5,6 +5,8 @@ libsuperiormysqlpp (0.3.1) UNRELEASED; urgency=medium
 
   [ Peter Opatril ]
   * Fix incorrect Clang detection in test makefile
+  * Replace outdated std::string_view::to_string method with string constructor, because
+    mentioned method was removed by C++17 standard.
 
  -- Daniel Pernis <daniel.pernis@firma.seznam.cz>  Thu, 06 Apr 2017 16:44:52 +0200
 


### PR DESCRIPTION
Method `to_string` in experimental (pre-C++17) version of `std::string_view` was removed from C++17 standard. New preferred (and backward compatible) way is calling std::string constructor.