### PR TITLE
Get rid of misleading error message from runtest.sh

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -5,7 +5,7 @@ PREFIX="`hostname`-`id -u`-`echo $$`-"
 IMAGE_NAME="${PREFIX}superiormysqlpp-test-mysql"
 CONTAINER_NAME="${PREFIX}superiormysqlpp-testdb"
 docker build --pull -t ${IMAGE_NAME} ../db
-docker rm -f ${CONTAINER_NAME} 2>&1 >/dev/null || true
+docker rm -f ${CONTAINER_NAME} >/dev/null 2>&1 || true
 docker run -d -P --name ${CONTAINER_NAME} ${IMAGE_NAME} #1>/dev/null
 MYSQL_HOST=`docker inspect --format='{{.NetworkSettings.IPAddress}}' ${CONTAINER_NAME}`
 set +e


### PR DESCRIPTION
The following misleading message will not be shown anymore:
"Error response from daemon: No such container: ..."

It's not intended to show this message to user before test are run.
It was caused by incorrect order while standard outputs are redirected.