### PR TITLE
Fix method typo isDestoyed -> is Destroyed

### DIFF
--- a/include/superior_mysqlpp/logging.hpp
+++ b/include/superior_mysqlpp/logging.hpp
@@ -742,7 +742,13 @@ namespace SuperiorMySqlpp {
         }
 
     public:
+        [[deprecated("Typo in method name; Use isDestroyed() method instead.")]]
         static bool isDestoyed()
+        {
+            return isDestroyed();
+        }
+
+        static bool isDestroyed()
         {
             return getInstanceUnsafe().destroyed;
         }

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -7,6 +7,10 @@ libsuperiormysqlpp (0.4.0) UNRELEASED; urgency=medium
   * Extend psReadValues exceptions
   * feat: Detect lost connection when using query
 
+  [ Radek Smejdir ]
+  * refactor: typo DefaultLogger::isDestoyed -> DefaultLogger::isDestroyed;
+    old method is deprecated
+
  -- Radek Smejdir <radek.smejdir@firma.seznam.cz>  Tue, 12 Mar 2019 13:37:35 +0100
 
 libsuperiormysqlpp (0.3.3) unstable; urgency=medium


### PR DESCRIPTION
This change breaks `DefaultLogger` interface and that should be reflected by increasing major version of package (or maybe minor version at least in case we haven't released version 1.0.0 yet).

Please update version number accordingly to this change when next release of package will be released, thanks.