### PR TITLE
Minor Makefile fixes

### DIFF
--- a/makefile
+++ b/makefile
@@ -22,6 +22,7 @@ INSTALL_INCLUDE =$(INSTALL) -m 644
 
 
 .PHONY: _print-variables test install clean clean-all packages-clean packages-clean-all packages-build packages-dbuild
+.PHONY: package-tar.gz package-tar.xz
 
 
 collapse-slashes =$(if $(findstring //,$1),$(call collapse-slashes,$(subst //,/,$1)),$(subst //,/,$1))
@@ -101,7 +102,6 @@ package-$1-clean-packages:
 package-$1-clean-all: package-$1-clean package-$1-clean-packages
 
 .PHONY: package-$1-build package-$1-build-install-dependencies package-$1-dbuild package-$1-clean package-$1-clean-packages package-$1-clean-all
-.PHONY: package-tar.gz package-tar.xz
 
 endef
 $(eval $(foreach package,$(deb_packages),$(call deb-package,$(package))))

--- a/makefile
+++ b/makefile
@@ -114,7 +114,7 @@ package-$1-build:
         --define "_topdir $(abspath ./)" \
         --define "_builddir $(abspath ./)" \
         --define "_buildrootdir $(abspath ./)/packages/$1/rpmbuild/" \
-        --define "_sourcedir $(abspath ./)" 
+        --define "_sourcedir $(abspath ./)" \
         --define "_rpmdir $(abspath ./)/packages/$1/" \
         --define "_smp_mflags -j$(CONCURRENCY)" \
         --define "_srcrpmdir $(abspath ./)/packages/$1/" \

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ include ./common.mk
 # if set then must end with '/'
 DESTDIR :=
 
-VERSION :=0.0.8
+VERSION := 0.3.1
 version_numbers :=$(subst ., ,$(VERSION))
 version_major :=$(word 1,$(version_numbers))
 


### PR DESCRIPTION
Some minor fixes in Makefile:
- aligning VERSION according to changelog
- added missing line-wrap char into multi-line command
- pacakge-tar.gz and package-tar.xz are defined once in .PHONY