### PR TITLE
Fix extended tests makefile and use them in packaging

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,6 +20,8 @@ INSTALL :=install
 INSTALL_LIB =$(INSTALL) -m 644
 INSTALL_INCLUDE =$(INSTALL) -m 644
 
+# Test for presence of boost_system. Currently, only actually needed part is Asio
+# that is used in extended tests and this seems to be reasonably efficient way to detect it.
 BOOST_LIB_PATHS = $(shell /sbin/ldconfig -p | grep 'libboost_system')
 ifneq ($(BOOST_LIB_PATHS),)
 	HAVE_BOOST_SYSTEM = 1

--- a/makefile
+++ b/makefile
@@ -20,10 +20,16 @@ INSTALL :=install
 INSTALL_LIB =$(INSTALL) -m 644
 INSTALL_INCLUDE =$(INSTALL) -m 644
 
+BOOST_LIB_PATHS = $(shell /sbin/ldconfig -p | grep 'libboost_system')
+ifneq ($(BOOST_LIB_PATHS),)
+	HAVE_BOOST_SYSTEM = 1
+else
+	HAVE_BOOST_SYSTEM = 0
+endif
 
-.PHONY: _print-variables test install clean clean-all packages-clean packages-clean-all packages-build packages-dbuild
+.PHONY: _print-variables test test-basic test-extended install clean clean-all packages-clean packages-clean-all packages-build packages-dbuild
 .PHONY: package-tar.gz package-tar.xz
-
+.NOTPARALLEL: test
 
 collapse-slashes =$(if $(findstring //,$1),$(call collapse-slashes,$(subst //,/,$1)),$(subst //,/,$1))
 list-directories =$(filter-out $(call collapse-slashes,$(dir $1/)),$(dir $(wildcard $(call collapse-slashes,$1/*/))))
@@ -53,10 +59,18 @@ _print-variables:
 	mkdir -p $@
 
 
-test:
+test-basic:
 	+$(MAKE) -C ./tests/ test
+test-extended:
+ifeq ($(HAVE_BOOST_SYSTEM),1)
+	+$(MAKE) -C ./tests-extended/ test
+else
+	$(error Extended tests skipped - Boost (libboost_system) is required and wasn't detected)
+endif
 
+test: test-basic test-extended
 
+	
 libsuperiormysqlpp.pc: libsuperiormysqlpp.pc.in makefile
 	sed \
          -e 's,@VERSION@,$(VERSION),' \

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -11,6 +11,8 @@ libsuperiormysqlpp (0.3.1) UNRELEASED; urgency=medium
   * Replace outdated std::string_view::to_string method with string constructor, because
     mentioned method was removed by C++17 standard.
   * Removed redundant zeroing memsets for std::vector, memsets for std::array made redundant by the use of initializer
+  * Add a way to run extended tests from primary makefile, make them run by default
+  * Add Boost as a suggestion for all packages, run extended tests during package creation
 
  -- Daniel Pernis <daniel.pernis@firma.seznam.cz>  Thu, 06 Apr 2017 16:44:52 +0200
 

--- a/packages/debian-jessie/dpkg-jail/debian/control
+++ b/packages/debian-jessie/dpkg-jail/debian/control
@@ -7,11 +7,11 @@ Build-Depends: debhelper(>=7),
                docker.io,
                libmysqlclient-dev,
                mysql-client,
-               libboost-system-dev
+               libboost-system-dev(>=1.49.0)
 Standards-Version: 3.7.2
 
 Package: libsuperiormysqlpp-dev
 Architecture: any
 Depends: libmysqlclient-dev
-Suggests: libboost-system-dev
+Suggests: libboost-system-dev(>=1.49.0)
 Description: C++ mysql library development files

--- a/packages/debian-jessie/dpkg-jail/debian/control
+++ b/packages/debian-jessie/dpkg-jail/debian/control
@@ -6,10 +6,12 @@ Build-Depends: debhelper(>=7),
                g++(>=4.9.2),
                docker.io,
                libmysqlclient-dev,
-               mysql-client
+               mysql-client,
+               libboost-system-dev
 Standards-Version: 3.7.2
 
 Package: libsuperiormysqlpp-dev
 Architecture: any
 Depends: libmysqlclient-dev
+Suggests: libboost-system-dev
 Description: C++ mysql library development files

--- a/packages/fedora-22/libsuperiormysqlpp.spec
+++ b/packages/fedora-22/libsuperiormysqlpp.spec
@@ -7,10 +7,12 @@ License:        LGPLv3+
 URL:            http://ftp.gnu.org/gnu/%{name}
 Source0:        http://ftp.gnu.org/gnu/%{name}/%{name}-%{version}.tar.gz
 
-BuildRequires:  docker, gcc-c++, community-mysql-devel, hostname, libasan, libubsan, tree
+BuildRequires:  docker, gcc-c++, community-mysql-devel, hostname, libasan, libubsan, tree, boost-devel
       
 Requires(post): info
 Requires(preun): info
+
+Suggests: boost-devel
 
 %description 
 C++ mysql library development files

--- a/packages/fedora-22/libsuperiormysqlpp.spec
+++ b/packages/fedora-22/libsuperiormysqlpp.spec
@@ -7,12 +7,12 @@ License:        LGPLv3+
 URL:            http://ftp.gnu.org/gnu/%{name}
 Source0:        http://ftp.gnu.org/gnu/%{name}/%{name}-%{version}.tar.gz
 
-BuildRequires:  docker, gcc-c++, community-mysql-devel, hostname, libasan, libubsan, tree, boost-devel
+BuildRequires:  docker, gcc-c++, community-mysql-devel, hostname, libasan, libubsan, tree, boost-devel >= 1.49.0
       
 Requires(post): info
 Requires(preun): info
 
-Suggests: boost-devel
+Suggests: boost-devel >= 1.49.0
 
 %description 
 C++ mysql library development files

--- a/packages/szn-debian-wheezy/dpkg-jail/debian/control
+++ b/packages/szn-debian-wheezy/dpkg-jail/debian/control
@@ -6,10 +6,12 @@ Build-Depends: debhelper(>=7),
                szn-g++(>=4.9.2),
                docker-engine,
                libmysqlclient-dev,
-               mysql-client
+               mysql-client,
+               libboost-system-dev
 Standards-Version: 3.7.2
 
 Package: libsuperiormysqlpp-dev
 Architecture: any
 Depends: libmysqlclient-dev
+Suggests: libboost-system-dev
 Description: C++ mysql library development files

--- a/packages/szn-debian-wheezy/dpkg-jail/debian/control
+++ b/packages/szn-debian-wheezy/dpkg-jail/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper(>=7),
                docker-engine,
                libmysqlclient-dev,
                mysql-client,
-               libboost-system-dev
+               libboost-system-dev(>=1.49.0)
 Standards-Version: 3.7.2
 
 Package: libsuperiormysqlpp-dev

--- a/tests-extended/makefile
+++ b/tests-extended/makefile
@@ -1,8 +1,15 @@
 #!/usr/bin/make -f
-include ../tests/makefile
 
 LDFLAGS += -lboost_system
 
 ifneq "$(shell id -u -r)" "0"
-PRE :=sudo 
+@echo "Note: This test will require elevated privileges."
+PRE := sudo
 endif
+
+runtest-path := ../tests
+
+# Overriding which files we use for One Definition Rule test
+odr_library_header_files = $(extended_functionality_header_files)
+
+include ../tests/makefile

--- a/tests/makefile
+++ b/tests/makefile
@@ -10,6 +10,8 @@ Q := @
 
 program :=tester
 odr :=odr_program
+runtest-path ?=.
+PRE ?= # command to run before test execution (good place for sudo)
 
 CXX ?=g++
 
@@ -52,11 +54,14 @@ LDLIBS += -lmysqlclient
 
 mangle-path =$(subst /,-_-,$1)
 demangle-path =$(subst -_-,/,$1)
-library_header_files :=$(sort $(patsubst ../include/%,%,$(shell find ../include/ -name "*.hpp")))
-odr_library_header_files :=$(filter-out superior_mysqlpp/dnsa_connection_pool.hpp,$(library_header_files))
-odr_source_files :=./odr/main.odr.cpp $(foreach i,1 2,$(foreach header_file,$(odr_library_header_files),./odr/$(call mangle-path,$(header_file:.hpp=.$(i).odr.cpp))))
-odr_object_files :=$(odr_source_files:.cpp=.o)
-odr_dependency_files :=$(odr_object_files:.o=.d)
+
+# following files are used only for extended tests
+extended_functionality_header_files := superior_mysqlpp/dnsa_connection_pool.hpp
+all_library_header_files := $(sort $(patsubst ../include/%,%,$(shell find ../include/ -name "*.hpp")))
+odr_library_header_files ?= $(filter-out $(extended_functionality_header_files),$(all_library_header_files))
+odr_source_files := ./odr/main.odr.cpp $(foreach i,1 2,$(foreach header_file,$(odr_library_header_files),./odr/$(call mangle-path,$(header_file:.hpp=.$(i).odr.cpp))))
+odr_object_files := $(odr_source_files:.cpp=.o)
+odr_dependency_files := $(odr_object_files:.o=.d)
 
 source_files :=$(sort $(shell find ./ -name "*.cpp" -not -name "*.odr.cpp"))
 object_files :=$(source_files:.cpp=.o)
@@ -115,7 +120,7 @@ build-basic: $(program)
 build: build-basic build-odr
 
 test-basic: $(program)
-	./runtest.sh
+	$(PRE) $(runtest-path)/runtest.sh
 
 test: test-basic build-odr
 


### PR DESCRIPTION
Add a way to run extended tests from primary makefile, make them run by default (in target `test`).
Running tests separately is still possible via `test-basic` and `test-extended`.
Add Boost as a suggestion for all packages, run extended tests during package creation.