### PR TITLE
Fix arraybase

### DIFF
--- a/include/superior_mysqlpp/types/array.hpp
+++ b/include/superior_mysqlpp/types/array.hpp
@@ -54,11 +54,15 @@ namespace SuperiorMySqlpp
             return std::min(itemsCount, static_cast<ItemsCount_t>(N));
         }
 
-        void assign(const ArrayBase& other)
+        template<std::size_t NN = N>
+        std::enable_if_t<(NN > 0),void> assign(const ArrayBase& other)
         {
             std::memcpy(array.data(), other.array.data(), other.size());
             itemsCount = other.size();
         }
+
+        template<std::size_t NN = N>
+        std::enable_if_t<(NN == 0),void> assign(const ArrayBase&) {}
 
     public:
         ItemsCount_t& counterRef()

--- a/include/superior_mysqlpp/types/array.hpp
+++ b/include/superior_mysqlpp/types/array.hpp
@@ -12,6 +12,9 @@
 
 namespace SuperiorMySqlpp
 {
+    /**
+     * Base class for all array based SQL types
+     */
     template<std::size_t N>
     class ArrayBase
     {

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -17,6 +17,9 @@ libsuperiormysqlpp (0.3.3) UNRELEASED; urgency=medium
   [ Michal Merc ]
   * fix: crash when destructing moved DBDriver
 
+  [ Peter Opatril ]
+  * Avoid calling memcpy for zero sized ArrayBase.
+
  -- Adam Stepan <adam.stepan@firma.seznam.cz>  Thu, 16 Aug 2018 09:09:37 +0200
 
 libsuperiormysqlpp (0.3.2) unstable; urgency=medium


### PR DESCRIPTION


 `assign` method called `memcpy` even when underlying array had size 0, leading to undefined behavior on `std::array::data` call.
