### PR TITLE
Remove useless macros from makefile

### DIFF
--- a/tests/makefile
+++ b/tests/makefile
@@ -23,9 +23,6 @@ endif
 CXXFLAGS += -std=c++14
 CXXFLAGS += -pedantic-errors
 CXXFLAGS += -Wall -Wextra -Wswitch-enum -Wnarrowing
-ifeq ($(HAVE_CLANG),1)
-    CXXFLAGS += -DHAVE_CLANG
-endif
 CXXFLAGS += -Werror
 CXXFLAGS += -fPIC
 CXXFLAGS += -fsanitize=address

--- a/tests/makefile
+++ b/tests/makefile
@@ -32,7 +32,6 @@ CXXFLAGS += -fsanitize=undefined
 CXXFLAGS += -g3
 CXXFLAGS += -I../include/
 CXXFLAGS += -I../third_party/bandit/
-CXXFLAGS += -DDEBUG
 CXXFLAGS += -O0
 CXXFLAGS += $(CXXEF)
 

--- a/tests/types/concat_iterator.cpp
+++ b/tests/types/concat_iterator.cpp
@@ -16,10 +16,6 @@ using namespace std::string_literals;
 
 
 
-#ifndef HAVE_CLANG
-#pragma GCC push_options
-#pragma GCC optimize ("O0")
-#endif
 go_bandit([](){
     describe("Test ConcatIterator", [&](){
         it("can work on empty vectors", [&](){
@@ -163,6 +159,3 @@ go_bandit([](){
         });
     });
 });
-#ifndef HAVE_CLANG
-#pragma GCC pop_options
-#endif


### PR DESCRIPTION
Basic makefile cleanup.
See commit messages for further details.