### PR TITLE
Removed unused build dependency

### DIFF
--- a/packages/debian-jessie/dpkg-jail/debian/control
+++ b/packages/debian-jessie/dpkg-jail/debian/control
@@ -6,7 +6,6 @@ Build-Depends: debhelper(>=9),
                g++(>=4.9.2),
                docker.io,
                libmysqlclient-dev,
-               mysql-client,
                libboost-system-dev(>=1.49.0)
 Standards-Version: 3.7.2
 

--- a/packages/szn-debian-wheezy/dpkg-jail/debian/control
+++ b/packages/szn-debian-wheezy/dpkg-jail/debian/control
@@ -6,7 +6,6 @@ Build-Depends: debhelper(>=9),
                szn-g++(>=4.9.2),
                docker-engine,
                libmysqlclient-dev,
-               mysql-client,
                libboost-system-dev(>=1.49.0)
 Standards-Version: 3.7.2
 


### PR DESCRIPTION
mysql-client in build-depends is useless, libmysqlclient-dev is needed only