### PR TITLE
Fix typo in test DB table name

### DIFF
--- a/db/test_database.sql
+++ b/db/test_database.sql
@@ -90,12 +90,12 @@ CREATE TABLE `time` (
     `timestamp` TIMESTAMP NOT NULL
 )  ENGINE=INNODB DEFAULT CHARSET=UTF8;
 
-DROP TABLE IF EXISTS `trucation_table`;
-CREATE TABLE `trucation_table` (
+DROP TABLE IF EXISTS `truncation_table`;
+CREATE TABLE `truncation_table` (
     `data` BLOB(100) NOT NULL
 )  ENGINE=INNODB DEFAULT CHARSET=UTF8;
-INSERT INTO `trucation_table` (`data`) VALUES (x'001100002412');
-INSERT INTO `trucation_table` (`data`) VALUES (x'42004100424242420042');
+INSERT INTO `truncation_table` (`data`) VALUES (x'001100002412');
+INSERT INTO `truncation_table` (`data`) VALUES (x'42004100424242420042');
 
 DROP TABLE IF EXISTS `simple_null`;
 CREATE TABLE `simple_null` (

--- a/tests/db_access/prepared_statements.cpp
+++ b/tests/db_access/prepared_statements.cpp
@@ -534,7 +534,7 @@ go_bandit([](){
 
         it("can detect truncation errors", [&](){
             auto preparedStatement = connection.makePreparedStatement<ResultBindings<StringDataBase<0>>>(
-                "SELECT `data` FROM `test_superior_sqlpp`.`trucation_table`"
+                "SELECT `data` FROM `test_superior_sqlpp`.`truncation_table`"
             );
             preparedStatement.execute();
             AssertThrows(MysqlDataTruncatedError, preparedStatement.fetch());
@@ -544,7 +544,7 @@ go_bandit([](){
             // 1. method - store result and allocate buffers before fetch
             {
                 auto preparedStatement = connection.makePreparedStatement<ResultBindings<StringDataBase<10>>>(
-                    "SELECT `data` FROM `test_superior_sqlpp`.`trucation_table`"
+                    "SELECT `data` FROM `test_superior_sqlpp`.`truncation_table`"
                 );
                 preparedStatement.setUpdateMaxLengthOnStore(true);
                 AssertThat(preparedStatement.getUpdateMaxLengthOnStore(), IsTrue());


### PR DESCRIPTION
It fixes only typo in table name for tests, library code is not affected at all