### PR TITLE
Fix exact int types

### DIFF
--- a/include/superior_mysqlpp/prepared_statements/binding_types.hpp
+++ b/include/superior_mysqlpp/prepared_statements/binding_types.hpp
@@ -13,6 +13,11 @@ namespace SuperiorMySqlpp
 {
     namespace detail
     {
+        /**
+         * Enumeration of various kinds of bindings.
+         * Integral and floating types are ommited, those types
+         * are referred to by appropriate primitive C type instead.
+         */
         enum class BindingTypes
         {
             Nullable,

--- a/include/superior_mysqlpp/prepared_statements/get_binding_type.hpp
+++ b/include/superior_mysqlpp/prepared_statements/get_binding_type.hpp
@@ -19,13 +19,14 @@ namespace SuperiorMySqlpp
         /**
          * Mapping of native C++ types to fitting MySQL field type.
          * @return FieldType enumeration of matching type.
-         * @remark This code is not completely portable - SQL types have exact size, C++ ones are architecture dependent.
+         * @remark Mapping between MySql and C types is based on specifications from underlying library
+         *         at https://dev.mysql.com/doc/refman/5.7/en/c-api-prepared-statement-type-codes.html
          */
         template<typename T>
         inline constexpr FieldTypes getBindingType() = delete;
 
         /**
-         * @remark Specialization for signed char, see generic version.
+         * @overload
          */
         template<>
         inline constexpr FieldTypes getBindingType<signed char>()
@@ -34,7 +35,7 @@ namespace SuperiorMySqlpp
         }
 
         /**
-         * @remark Specialization for short, see generic version.
+         * @overload
          */
         template<>
         inline constexpr FieldTypes getBindingType<short int>()
@@ -43,7 +44,7 @@ namespace SuperiorMySqlpp
         }
 
         /**
-         * @remark Specialization for int, see generic version.
+         * @overload
          */
         template<>
         inline constexpr FieldTypes getBindingType<int>()
@@ -52,16 +53,18 @@ namespace SuperiorMySqlpp
         }
 
         /**
-         * @remark Specialization for long int, see generic version.
+         * @overload
          */
         template<>
         inline constexpr FieldTypes getBindingType<long int>()
         {
+            static_assert(sizeof(long int) == sizeof(long long int),
+                "Underlying library doesn't specify what MySql type represent C type ==long int==. Let's assume it's identical to ==long long int==.");
             return FieldTypes::LongLong;
         }
 
         /**
-         * @remark Specialization for long long, see generic version.
+         * @overload
          */
         template<>
         inline constexpr FieldTypes getBindingType<long long int>()
@@ -70,7 +73,7 @@ namespace SuperiorMySqlpp
         }
 
         /**
-         * @remark Specialization for float, see generic version.
+         * @overload
          */
         template<>
         inline constexpr FieldTypes getBindingType<float>()
@@ -79,7 +82,7 @@ namespace SuperiorMySqlpp
         }
 
         /**
-         * @remark Specialization for double, see generic version.
+         * @overload
          */
         template<>
         inline constexpr FieldTypes getBindingType<double>()

--- a/include/superior_mysqlpp/prepared_statements/initialize_bindings.hpp
+++ b/include/superior_mysqlpp/prepared_statements/initialize_bindings.hpp
@@ -65,7 +65,7 @@ namespace SuperiorMySqlpp
 
             binding.buffer = &value;
             binding.buffer_type = detail::toMysqlEnum(getBindingType<Signed_t>());
-            binding.is_unsigned = std::is_unsigned<PureType_t>()? true : false;
+            binding.is_unsigned = std::is_unsigned<PureType_t>::value;
         }
 
         /**


### PR DESCRIPTION
As SQL uses exact-width integer types, using native C ints may cause portability issues - this PR rewrites such occurences.

Note that this currently causes warnings in test suite.
They are not errors (only hint at usage of inappropriate type) but probably should be fixed.

EDIT:
After review, this PR scope changed - native C ints are not arbitrary, but are explicitly specified in underlying C library, so this PR will be limited to highlighting that fact.