### PR TITLE
Remove redundancy

### DIFF
--- a/include/superior_mysqlpp/dnsa_connection_pool.hpp
+++ b/include/superior_mysqlpp/dnsa_connection_pool.hpp
@@ -15,7 +15,6 @@
 
 #include <superior_mysqlpp/connection_pool.hpp>
 #include <superior_mysqlpp/shared_ptr_pool/sleep_in_parts.hpp>
-#include <superior_mysqlpp/dnsa_connection_pool.hpp>
 
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/tcp.hpp>

--- a/include/superior_mysqlpp/prepared_statements/prepared_statement_base.hpp
+++ b/include/superior_mysqlpp/prepared_statements/prepared_statement_base.hpp
@@ -359,11 +359,6 @@ namespace SuperiorMySqlpp
             template<typename ResultBindings>
             void validateResultMetadata(const ResultBindings& resultBindings)
             {
-                using namespace std::string_literals;
-                using std::to_string;
-                using std::begin;
-                using std::end;
-
                 if (validateMode==ValidateMetadataMode::Disabled && warnMode==ValidateMetadataMode::Disabled)
                 {
                     return;
@@ -372,10 +367,10 @@ namespace SuperiorMySqlpp
                 auto&& metadata = this->getResultMetadata();
 
                 std::size_t index = 0;
-                auto bindingsIt=begin(resultBindings);
-                auto bindingsEndIt=end(resultBindings);
-                auto metadataIt=begin(metadata);
-                auto metadataEndIt=end(metadata);
+                auto bindingsIt=std::begin(resultBindings);
+                auto bindingsEndIt=std::end(resultBindings);
+                auto metadataIt=std::begin(metadata);
+                auto metadataEndIt=std::end(metadata);
                 while (bindingsIt!=bindingsEndIt && metadataIt!=metadataEndIt)
                 {
                     auto&& binding = *bindingsIt;

--- a/include/superior_mysqlpp/prepared_statements/prepared_statement_base.hpp
+++ b/include/superior_mysqlpp/prepared_statements/prepared_statement_base.hpp
@@ -181,15 +181,6 @@ namespace SuperiorMySqlpp
             std::vector<detail::NullableBase*> nullableBindings;
 
         public:
-            /**
-             * Appears unused, probably can be removed.
-             * Is defined exactly like (private) DBDriver::size_t, so
-             * it was presumably added for similiar purpose.
-             * !!!!!
-             */
-            using size_t = unsigned long long;
-
-        public:
             using StoreOrUseResultBase<storeResult>::StoreOrUseResultBase;
 
         private:

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -12,8 +12,10 @@ libsuperiormysqlpp (0.4.0) UNRELEASED; urgency=medium
     old method is deprecated
 
   [ Peter Opatril ]
-  * fix: Base type of BadNullableAccess
+  * fix: base type of BadNullableAccess
   * refactor: useless const_cast
+  * refactor: unused using declarations
+  * refactor: redundant cyclic include dependency
 
  -- Radek Smejdir <radek.smejdir@firma.seznam.cz>  Tue, 12 Mar 2019 13:37:35 +0100
 


### PR DESCRIPTION
Removal of useless declarations. Note that in case of local `size_t`, the definition is public.