### PR TITLE
Travis-CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: cpp
+os: linux
+sudo: required
+services: docker
+branches:
+  only:
+    - master
+    - devel
+script:
+  - make CONCURRENCY=4 package-debian-stretch-dbuild
+  - make CONCURRENCY=4 package-debian-jessie-dbuild
+  - make CONCURRENCY=4 package-fedora-22-dbuild

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 SuperiorMySQL++
 ====================================================
+[![Build Status](https://travis-ci.org/seznam/SuperiorMySqlpp.svg?branch=master)](https://travis-ci.org/seznam/SuperiorMySqlpp) - master branch  
+[![Build Status](https://travis-ci.org/seznam/SuperiorMySqlpp.svg?branch=devel)](https://travis-ci.org/seznam/SuperiorMySqlpp) - devel branch  
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](LICENSE)  
+
 Modern C++ wrapper for MySQL C API
 
 **Author**: [Tomas Nozicka](https://github.com/tnozicka), [*Seznam.cz*](https://github.com/seznam)


### PR DESCRIPTION
Test package building (including running unit tests) for all supported
platforms (currently Debian Stretch, Debian Jessie, Fedora 22).

! Please create `seznam` account on travis-ci.org