### PR TITLE
Remove useless method DBDriver::Result::freeResult()

### DIFF
--- a/include/superior_mysqlpp/low_level/dbdriver.hpp
+++ b/include/superior_mysqlpp/low_level/dbdriver.hpp
@@ -447,18 +447,6 @@ namespace SuperiorMySqlpp { namespace LowLevel
             /** Pointer to underlying library's result set instance. */
             MYSQL_RES* resultPtr;
 
-            /**
-             * Frees allocated memory for current result set.
-             * @see https://dev.mysql.com/doc/refman/5.7/en/mysql-free-result.html
-             */
-            void close() noexcept
-            {
-                if (resultPtr != nullptr)
-                {
-                    mysql_free_result(resultPtr);
-                }
-            }
-
         public:
             /**
              * Constructs object directly from MySQL's result set represented by MYSQL_RES structure.
@@ -493,8 +481,8 @@ namespace SuperiorMySqlpp { namespace LowLevel
              */
             Result& operator=(Result&& result) noexcept
             {
-                static_assert(noexcept(close()), "close() must be noexcept!");
-                close();
+                static_assert(noexcept(freeResult()), "freeResult() must be noexcept!");
+                freeResult();
                 resultPtr = result.resultPtr;
                 result.resultPtr = nullptr;
                 return *this;
@@ -506,7 +494,7 @@ namespace SuperiorMySqlpp { namespace LowLevel
              */
             ~Result()
             {
-                close();
+                freeResult();
             }
 
 
@@ -628,6 +616,19 @@ namespace SuperiorMySqlpp { namespace LowLevel
                 return mysql_field_tell(resultPtr);
             }
 
+            /**
+             * Frees allocated memory for current result set.
+             * @see https://dev.mysql.com/doc/refman/5.7/en/mysql-free-result.html
+             */
+            void freeResult() noexcept
+            {
+                if (resultPtr != nullptr)
+                     {
+                         mysql_free_result(resultPtr);
+                         resultPtr = nullptr;
+                     }
+            }
+            
             /**
              * Returns number of columns in a result set.
              * @see https://dev.mysql.com/doc/refman/5.7/en/mysql-num-fields.html

--- a/include/superior_mysqlpp/low_level/dbdriver.hpp
+++ b/include/superior_mysqlpp/low_level/dbdriver.hpp
@@ -627,18 +627,7 @@ namespace SuperiorMySqlpp { namespace LowLevel
             {
                 return mysql_field_tell(resultPtr);
             }
-
-            /**
-             * Frees allocated memory for current result set.
-             * @see https://dev.mysql.com/doc/refman/5.7/en/mysql-free-result.html
-             *
-             * @return Void - nothing!
-             */
-            auto freeResult()
-            {
-                return mysql_free_result(resultPtr);
-            }
-
+            
             /**
              * Returns number of columns in a result set.
              * @see https://dev.mysql.com/doc/refman/5.7/en/mysql-num-fields.html

--- a/include/superior_mysqlpp/low_level/dbdriver.hpp
+++ b/include/superior_mysqlpp/low_level/dbdriver.hpp
@@ -627,7 +627,7 @@ namespace SuperiorMySqlpp { namespace LowLevel
             {
                 return mysql_field_tell(resultPtr);
             }
-            
+
             /**
              * Returns number of columns in a result set.
              * @see https://dev.mysql.com/doc/refman/5.7/en/mysql-num-fields.html

--- a/include/superior_mysqlpp/low_level/dbdriver.hpp
+++ b/include/superior_mysqlpp/low_level/dbdriver.hpp
@@ -623,12 +623,12 @@ namespace SuperiorMySqlpp { namespace LowLevel
             void freeResult() noexcept
             {
                 if (resultPtr != nullptr)
-                     {
-                         mysql_free_result(resultPtr);
-                         resultPtr = nullptr;
-                     }
+                {
+                    mysql_free_result(resultPtr);
+                    resultPtr = nullptr;
+                }
             }
-            
+
             /**
              * Returns number of columns in a result set.
              * @see https://dev.mysql.com/doc/refman/5.7/en/mysql-num-fields.html

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -1,10 +1,10 @@
-libsuperiormysqlpp (0.4.0) UNRELEASED; urgency=medium
+libsuperiormysqlpp (0.3.3) UNRELEASED; urgency=medium
 
   [ Radek Smejdir ]
   * Add ConnectionConfiguration
 
   [ Tomas Prochazka ]
-  * Removed useless method DBDriver::Result::close() and substituted with method freeResult()
+  * Removed useless private method DBDriver::Result::close() and substituted with method freeResult()
 
  -- Michal Fizek <michal.fizek@firma.seznam.cz>  Mon, 23 Apr 2018 14:17:57 +0200
 

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -4,7 +4,7 @@ libsuperiormysqlpp (0.4.0) UNRELEASED; urgency=medium
   * Add ConnectionConfiguration
 
   [ Tomas Prochazka ]
-  * Removed useless method DBDriver::Result::freeResult() 
+  * Removed useless method DBDriver::Result::freeResult()  
 
  -- Michal Fizek <michal.fizek@firma.seznam.cz>  Mon, 23 Apr 2018 14:17:57 +0200
 

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -4,7 +4,7 @@ libsuperiormysqlpp (0.4.0) UNRELEASED; urgency=medium
   * Add ConnectionConfiguration
 
   [ Tomas Prochazka ]
-  * Removed useless method DBDriver::Result::freeResult()
+  * Removed useless method DBDriver::Result::close() and substituted with method freeResult()
 
  -- Michal Fizek <michal.fizek@firma.seznam.cz>  Mon, 23 Apr 2018 14:17:57 +0200
 

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -1,7 +1,10 @@
-libsuperiormysqlpp (0.3.3) UNRELEASED; urgency=medium
+libsuperiormysqlpp (0.4.0) UNRELEASED; urgency=medium
 
   [ Radek Smejdir ]
   * Add ConnectionConfiguration
+
+  [ Tomas Prochazka ]
+  * Removed useless method DBDriver::Result::freeResult() 
 
  -- Michal Fizek <michal.fizek@firma.seznam.cz>  Mon, 23 Apr 2018 14:17:57 +0200
 

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -4,7 +4,7 @@ libsuperiormysqlpp (0.4.0) UNRELEASED; urgency=medium
   * Add ConnectionConfiguration
 
   [ Tomas Prochazka ]
-  * Removed useless method DBDriver::Result::freeResult()  
+  * Removed useless method DBDriver::Result::freeResult()
 
  -- Michal Fizek <michal.fizek@firma.seznam.cz>  Mon, 23 Apr 2018 14:17:57 +0200
 


### PR DESCRIPTION
The method DBDriver::Result::freeResult() is never used and thus can be removed

Closes the issue #80 