### PR TITLE
Refactor: using long-opts in build scripts

### DIFF
--- a/makefile
+++ b/makefile
@@ -17,12 +17,12 @@ libdir =$(prefix)/lib
 includedir =$(prefix)/include
 
 INSTALL :=install
-INSTALL_LIB =$(INSTALL) -m 644
-INSTALL_INCLUDE =$(INSTALL) -m 644
+INSTALL_LIB =$(INSTALL) --mode=644
+INSTALL_INCLUDE =$(INSTALL) --mode=644
 
 # Test for presence of boost_system. Currently, only actually needed part is Asio
 # that is used in extended tests and this seems to be reasonably efficient way to detect it.
-BOOST_LIB_PATHS = $(shell /sbin/ldconfig -p | grep 'libboost_system')
+BOOST_LIB_PATHS = $(shell /sbin/ldconfig --print-cache | grep 'libboost_system')
 ifneq ($(BOOST_LIB_PATHS),)
 	HAVE_BOOST_SYSTEM = 1
 else
@@ -36,7 +36,7 @@ endif
 collapse-slashes =$(if $(findstring //,$1),$(call collapse-slashes,$(subst //,/,$1)),$(subst //,/,$1))
 list-directories =$(filter-out $(call collapse-slashes,$(dir $1/)),$(dir $(wildcard $(call collapse-slashes,$1/*/))))
 define make-directory
-$(call collapse-slashes,mkdir -p $1)
+$(call collapse-slashes,mkdir --parents $1)
 
 endef
 
@@ -58,16 +58,16 @@ _print-variables:
 
 # pravidlo pro vsechny adresare (makefile nechape v pravidlech "%/:")
 %/.:
-	mkdir -p $@
+	mkdir --parents $@
 
 
 test-basic:
-	+$(MAKE) -C ./tests/ test
+	+$(MAKE) --directory ./tests/ test
 test-extended:
 ifeq ($(HAVE_BOOST_SYSTEM),1)
-	+$(MAKE) -C ./tests-extended/ test
+	+$(MAKE) --directory ./tests-extended/ test
 else
-	$(error Extended tests skipped - Boost (libboost_system) is required and wasn't detected)
+	$(error Extended tests skipped - Boost (libboost_system) is required and was not detected)
 endif
 
 test: test-basic test-extended
@@ -75,8 +75,8 @@ test: test-basic test-extended
 
 libsuperiormysqlpp.pc: libsuperiormysqlpp.pc.in makefile
 	sed \
-         -e 's,@VERSION@,$(VERSION),' \
-         -e 's,@PREFIX@,$(prefix),' \
+         --expression='s,@VERSION@,$(VERSION),' \
+         --expression='s,@PREFIX@,$(prefix),' \
          libsuperiormysqlpp.pc.in > $@
 
 
@@ -85,15 +85,15 @@ install: $(DESTDIR)$(includedir)/.
 install: libsuperiormysqlpp.pc
 install:
 	$(call recursive-install,$(INSTALL_INCLUDE),./include,*.hpp,$(DESTDIR)$(includedir)/)
-	$(INSTALL) -d $(DESTDIR)/$(libdir)/pkgconfig
-	$(INSTALL) -t $(DESTDIR)/$(libdir)/pkgconfig -m 644 libsuperiormysqlpp.pc
+	$(INSTALL) --directory $(DESTDIR)/$(libdir)/pkgconfig
+	$(INSTALL) --target-directory=$(DESTDIR)/$(libdir)/pkgconfig --mode=644 libsuperiormysqlpp.pc
 
 
 
 clean:
 	find ./ -type f -name "core" -exec $(RM) {} \;
-	+$(MAKE) -C ./tests/ clean
-	+$(MAKE) -C ./tests-extended/ clean
+	+$(MAKE) --directory ./tests/ clean
+	+$(MAKE) --directory ./tests-extended/ clean
 
 clean-all: clean packages-clean-all
 
@@ -107,7 +107,7 @@ package-$1-build:
 	+cd packages/$1/dpkg-jail/ && dpkg-buildpackage -j$(CONCURRENCY) -B -us -uc
 
 package-$1-build-install-dependencies:
-	cd packages/$1/dpkg-jail/ && mk-build-deps -i -r -t 'apt-get -f -y'
+	cd packages/$1/dpkg-jail/ && mk-build-deps --install --remove --tool 'apt-get --fix-broken --assume-yes'
 
 package-$1-clean:
 	+$(if $(shell which dh_clean 2>&1 2>/dev/null),cd packages/$1/dpkg-jail/ && dh_clean,)
@@ -138,10 +138,10 @@ package-$1-build:
 	*.spec)
 
 package-$1-build-install-dependencies:
-	cd packages/$1/ && dnf builddep -y *.spec
+	cd packages/$1/ && dnf builddep --assumeyes *.spec
 
 package-$1-clean:
-	$(RM) -R $(abspath ./)/packages/$1/rpmbuild/
+	$(RM) --recursive $(abspath ./)/packages/$1/rpmbuild/
 
 package-$1-clean-packages:
 	$(RM) packages/$1/*.rpm
@@ -155,7 +155,7 @@ $(eval $(foreach package,$(rpm_packages),$(call rpm-package,$(package))))
 
 
 ifneq "$(CONCURRENCY)" ""
-docker_run_concurrency :=-e "CONCURRENCY=$(CONCURRENCY)"
+docker_run_concurrency :=--env="CONCURRENCY=$(CONCURRENCY)"
 endif
 
 # LeakSanitizer (lsan) needs ptrace and by default docker denies it
@@ -184,7 +184,7 @@ packages-dbuild: $(foreach package,$(packages),package-$(package)-dbuild )
 
 
 package-tar.gz: clean-all
-	tar -czf libsuperiormysqlpp-$(VERSION).tar.gz *
+	tar --create --gzip --file=libsuperiormysqlpp-$(VERSION).tar.gz *
 
 package-tar.xz: clean-all
-	tar -cJf libsuperiormysqlpp-$(VERSION).tar.xz *
+	tar --create --xz --file=libsuperiormysqlpp-$(VERSION).tar.xz *

--- a/makefile
+++ b/makefile
@@ -162,8 +162,9 @@ endif
 define any-package
 package-$1-dbuild:
 	cd packages/$1/ && $(docker_build) --tag=package-$1-dbuild .
-	docker run --name $(IMAGE_PREFIX)dbuild-$1 -t -v /var/run/docker.sock:/var/run/docker.sock -v `pwd`:/dbuild/sources $(docker_run_concurrency) --cap-add SYS_PTRACE package-$1-dbuild
-	docker rm $(IMAGE_PREFIX)dbuild-$1 2>&1 1>/dev/null
+	docker run --rm --name $(IMAGE_PREFIX)dbuild-$1 --tty $(docker_run_concurrency) --cap-add SYS_PTRACE \
+		--volume=/var/run/docker.sock:/var/run/docker.sock --volume=`pwd`:/dbuild/sources \
+		package-$1-dbuild
 
 .PHONY: package-$1-dbuild
 

--- a/packages/debian-jessie/Dockerfile
+++ b/packages/debian-jessie/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Seznam.cz a.s.
 
 ENV CONCURRENCY 32
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install --assume-yes \
     apt-transport-https \
     devscripts \
     dpkg-dev \

--- a/packages/debian-jessie/docker-run.sh
+++ b/packages/debian-jessie/docker-run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-cp -r /dbuild/sources /dbuild/building
+cp --recursive /dbuild/sources /dbuild/building
 cd /dbuild/building
 make -j${CONCURRENCY} clean
 

--- a/packages/debian-stretch/Dockerfile
+++ b/packages/debian-stretch/Dockerfile
@@ -3,18 +3,18 @@ LABEL maintainer="Seznam.cz a.s."
 
 ENV CONCURRENCY=32
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install --assume-yes \
     apt-transport-https \
     devscripts \
     dpkg-dev \
     equivs \
     make \
 && echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-5.0 main" > /etc/apt/sources.list.d/llvm.list \
-&& curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - >/dev/null 2>&1 \
+&& curl --fail --silent --show-error --location https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - >/dev/null 2>&1 \
 && echo "deb [arch=amd64] https://download.docker.com/linux/debian stretch stable" >> /etc/apt/sources.list.d/docker.list \
-&& curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - >/dev/null 2>&1 \
+&& curl --fail --silent --show-error --location https://download.docker.com/linux/debian/gpg | apt-key add - >/dev/null 2>&1 \
 && echo "deb http://repo.mysql.com/apt/debian/ stretch mysql-5.7" > /etc/apt/sources.list.d/mysql.list \
-&& curl -fsSL https://repo.mysql.com/RPM-GPG-KEY-mysql | apt-key add - >/dev/null 2>&1 \
+&& curl --fail --silent --show-error --location https://repo.mysql.com/RPM-GPG-KEY-mysql | apt-key add - >/dev/null 2>&1 \
 # OPTIONALLY use MariaDB 10.2 repository instead of MySQL 5.7 repo
 #&& echo "deb [arch=amd64,i386,ppc64el] http://mirror.vpsfree.cz/mariadb/repo/10.2/debian stretch main" > /etc/apt/sources.list.d/mariadb.list \
 #&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0xF1656F24C74CD1D8 >/dev/null 2>&1 \

--- a/packages/debian-stretch/docker-run.sh
+++ b/packages/debian-stretch/docker-run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-cp -r /dbuild/sources /dbuild/building
+cp --recursive /dbuild/sources /dbuild/building
 cd /dbuild/building
 make -j${CONCURRENCY} clean
 

--- a/packages/fedora-22/Dockerfile
+++ b/packages/fedora-22/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Seznam.cz a.s.
 ENV CONCURRENCY 32
 
 RUN \
-dnf install -y \
+dnf install --assumeyes \
     dnf-plugins-core \
     findutils \
     hostname \

--- a/packages/fedora-22/docker-run.sh
+++ b/packages/fedora-22/docker-run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-cp -r /dbuild/sources /dbuild/building
+cp --recursive /dbuild/sources /dbuild/building
 cd /dbuild/building
 make -j${CONCURRENCY} clean
 

--- a/tests/makefile
+++ b/tests/makefile
@@ -16,7 +16,7 @@ PRE ?= # command to run before test execution (good place for sudo)
 CXX ?=g++
 
 HAVE_CLANG := 0
-ifeq ($(shell $(CXX) -v 2>&1 | grep -c "clang version"), 1)
+ifeq ($(shell $(CXX) --version 2>&1 | grep --count "clang version"), 1)
     HAVE_CLANG := 1
 endif
 
@@ -75,7 +75,7 @@ print-variables:
 
 # rule for all dirs (makefile does not get "%/:")
 %/.:
-	$(Q) mkdir -p $@
+	$(Q) mkdir --parents $@
 	$(info Generating test files for ODR...)
 
 odr/main.odr.cpp: $(filter-out $(wildcard ./odr/.), ./odr/.)
@@ -123,6 +123,6 @@ clean-files =find ./ -type f -path "$1" -exec $(RM) {} \;
 
 clean:
 	$(RM) $(program) $(odr)
-	$(RM) -fR ./odr/
+	$(RM) --recursive --force ./odr/
 	$(call clean-files,*.d)
 	$(call clean-files,*.o)

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 set -e
-PREFIX="`hostname`-`id -u`-`echo $$`-"
+PREFIX="`hostname`-`id --user`-`echo $$`-"
 IMAGE_NAME="${PREFIX}superiormysqlpp-test-mysql"
 CONTAINER_NAME="${PREFIX}superiormysqlpp-testdb"
-docker build --pull -t ${IMAGE_NAME} ../db
-docker rm -f ${CONTAINER_NAME} >/dev/null 2>&1 || true
-docker run -d -P --name ${CONTAINER_NAME} ${IMAGE_NAME} #1>/dev/null
+docker build --pull --tag=${IMAGE_NAME} ../db
+docker rm --force ${CONTAINER_NAME} >/dev/null 2>&1 || true
+docker run --detach --publish-all --name ${CONTAINER_NAME} ${IMAGE_NAME} #1>/dev/null
 MYSQL_HOST=`docker inspect --format='{{.NetworkSettings.IPAddress}}' ${CONTAINER_NAME}`
 set +e
 
@@ -20,13 +20,13 @@ socat "UNIX-LISTEN:$LOCAL_TMP_SOCKET,fork,reuseaddr,unlink-early,mode=777" \
 RESULT=$?
 
 ## TODO Add option to run test in manual mode.
-## It's needed to run docker in interactive mode to get `read` command working, just add `-i` option to docker run in main project's makefile.
+## It's needed to run docker in interactive mode to get `read` command working, just add `--interactive` option to docker run in main project's makefile.
 #echo
 #echo "To connect to test DB:
-#echo "  mysql -uroot -ppassword -h $MYSQL_HOST -P 3306"
+#echo "  mysql --user=root --password=password --host=$MYSQL_HOST --port=3306"
 #echo "To manually test socket forwarding through 3307, try:"
-#echo "  mysql -uroot -ppassword -h $MYSQL_HOST -P 3307"
-#echo "  mysql -uroot -ppassword --socket $LOCAL_TMP_SOCKET"
+#echo "  mysql --user=root --password=password --host=$MYSQL_HOST --port=3307"
+#echo "  mysql --user=root --password=password --socket=$LOCAL_TMP_SOCKET"
 #echo "To run some test case again:"
 #echo "  ./tester ${MYSQL_HOST} 3306 ${CONTAINER_NAME} ${LOCAL_TMP_SOCKET} --reporter=spec --only=<test-name-substring>"
 #echo
@@ -37,7 +37,7 @@ RESULT=$?
 kill $!
 
 echo "Removing temporary created docker container ..."
-docker rm -f ${CONTAINER_NAME}
+docker rm --force ${CONTAINER_NAME}
 
 if [ ! "$?" -eq "0" ]; then
     echo >&2 "Removing docker container '${CONTAINER_NAME}' failed"


### PR DESCRIPTION
Using long variants of parameters is self-describing and it makes build scripts much more clear to reader.
Also `docker run --rm` was used when packages are build instead of calling `docker run` and `docker rm` separately.