### PR TITLE
fix: crashing when connection object is moved

### DIFF
--- a/include/superior_mysqlpp/low_level/dbdriver.hpp
+++ b/include/superior_mysqlpp/low_level/dbdriver.hpp
@@ -204,7 +204,7 @@ namespace SuperiorMySqlpp { namespace LowLevel
         DBDriver& operator=(const DBDriver&) = delete;
 
         DBDriver(DBDriver&& drv)
-            : connected { drv.connected }, id { drv.id }, mysql { drv.mysql },
+            : connected { drv.connected }, id { drv.id }, mysql(drv.mysql),
               loggerPtr { std::move(drv.loggerPtr) }
         {
             drv.connected = false;

--- a/include/superior_mysqlpp/low_level/dbdriver.hpp
+++ b/include/superior_mysqlpp/low_level/dbdriver.hpp
@@ -204,7 +204,7 @@ namespace SuperiorMySqlpp { namespace LowLevel
         DBDriver& operator=(const DBDriver&) = delete;
 
         DBDriver(DBDriver&& drv)
-            : connected { drv.connected }, id { drv.id }, mysql(drv.mysql),
+            : connected { drv.connected }, valid { drv.valid }, id { drv.id }, mysql(drv.mysql),
               loggerPtr { std::move(drv.loggerPtr) }
         {
             drv.connected = false;

--- a/include/superior_mysqlpp/low_level/dbdriver.hpp
+++ b/include/superior_mysqlpp/low_level/dbdriver.hpp
@@ -98,7 +98,7 @@ namespace SuperiorMySqlpp { namespace LowLevel
     class DBDriver
     {
     private:
-        /** Internal ID; each instance have unique ID. */
+        /** Internal ID; each instance have unique ID. 0 means invalid/not connected state */
         std::uint_fast64_t id;
         /** Connection handler settings. */
         MYSQL mysql;

--- a/include/superior_mysqlpp/low_level/dbdriver.hpp
+++ b/include/superior_mysqlpp/low_level/dbdriver.hpp
@@ -103,7 +103,7 @@ namespace SuperiorMySqlpp { namespace LowLevel
         /** Validity status */
         bool valid = false;
         /** Internal ID; each instance have unique ID. */
-        const std::uint_fast64_t id;
+        /* const */ std::uint_fast64_t id;
         /** Connection handler settings. */
         MYSQL mysql;
         /** Logger instance pointer. */
@@ -209,6 +209,7 @@ namespace SuperiorMySqlpp { namespace LowLevel
         {
             drv.connected = false;
             drv.valid = false;
+            drv.id = getGlobalIdRef().fetch_add(1);
         }
 
         DBDriver& operator=(DBDriver&&) = delete;

--- a/include/superior_mysqlpp/low_level/dbdriver.hpp
+++ b/include/superior_mysqlpp/low_level/dbdriver.hpp
@@ -165,8 +165,12 @@ namespace SuperiorMySqlpp { namespace LowLevel
          */
         void mysqlClose()
         {
-            getLogger()->logMySqlClose(id);
-            mysql_close(getMysqlPtr());
+            if (connected)
+            {
+                getLogger()->logMySqlClose(id);
+                mysql_close(getMysqlPtr());
+                connected = false;
+            }
         }
 
 
@@ -192,7 +196,14 @@ namespace SuperiorMySqlpp { namespace LowLevel
         DBDriver(const DBDriver&) = delete;
         DBDriver& operator=(const DBDriver&) = delete;
 
-        DBDriver(DBDriver&&) = default;
+        DBDriver(DBDriver&& drv)
+            : connected { drv.connected }, id { drv.id }, mysql { drv.mysql },
+              loggerPtr { std::move(drv.loggerPtr) }
+        {
+            drv.connected = false;
+            mysqlInit();
+        }
+
         DBDriver& operator=(DBDriver&&) = delete;
 
 

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -14,6 +14,9 @@ libsuperiormysqlpp (0.3.3) UNRELEASED; urgency=medium
   * Add noexcept qualifier to database driver methods
   * Fix behavior of makeHexString
 
+  [ Michal Merc ]
+  * fix: crash when destructing moved DBDriver
+
  -- Adam Stepan <adam.stepan@firma.seznam.cz>  Thu, 16 Aug 2018 09:09:37 +0200
 
 libsuperiormysqlpp (0.3.2) unstable; urgency=medium

--- a/tests/db_access/connection.cpp
+++ b/tests/db_access/connection.cpp
@@ -149,6 +149,12 @@ go_bandit([](){
 
             Connection connection{socketConfig};
         });
+
+        it("does not crash when stealing connection", [&]() {
+            auto& s = getSettingsRef();
+            Connection connection{s.database, s.user, s.password, s.host, s.port};
+            Connection conn2 = std::move(connection);
+        });
     });
 });
 


### PR DESCRIPTION
Fix crash (segmentation fault) when you attempt to run following scenario:
```c++
SuperiorMySqlpp::Connection movedFrom = makeConnection();
SuperiorMySqlpp::Connection connection = std::move(movedFrom);
```