### PR TITLE
fix: Debian-Jessie build

### DIFF
--- a/packages/debian-jessie/Dockerfile
+++ b/packages/debian-jessie/Dockerfile
@@ -3,13 +3,15 @@ MAINTAINER Seznam.cz a.s.
 
 ENV CONCURRENCY 32
 
-RUN \
-echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/sources.list.d/jessie_backports.list \
-&& apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
     devscripts \
     dpkg-dev \
     equivs \
-    make
+    make \
+&& echo "deb [arch=amd64] https://download.docker.com/linux/debian jessie stable" >> /etc/apt/sources.list.d/docker.list \
+&& curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - >/dev/null 2>&1 \
+&& apt-get update
 
 VOLUME /dbuild/sources
 

--- a/packages/debian-jessie/dpkg-jail/debian/control
+++ b/packages/debian-jessie/dpkg-jail/debian/control
@@ -4,7 +4,7 @@ Priority: extra
 Maintainer: Tomas Nozicka, Seznam.cz
 Build-Depends: debhelper(>=9),
                g++(>=4.9.2),
-               docker.io,
+               docker-ce,
                libmysqlclient-dev,
                libboost-system-dev(>=1.49.0),
                socat


### PR DESCRIPTION
- docker.io is not available on jessie anymore - using standard docker repo and docker-ce package instead
- removed unnecessary jessie-backports mirror for building a package