### PR TITLE
refactor: Change order of arguments of psQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ while (preparedStatement.fetch())
 
 Invokes psQuery with param setter only.
 ```c++
-psParamQuery("INSERT INTO ... (col1, col2, ...) VALUES (?, ?, ...)", connection, [&](T1 &col1, T2& col2, ...) -> bool {
+psParamQuery(connection, "INSERT INTO ... (col1, col2, ...) VALUES (?, ?, ...)", [&](T1 &col1, T2& col2, ...) -> bool {
     col1 = ...;
     col2 = ...;
     return true; // Or false, if we want to stop
@@ -273,16 +273,16 @@ psParamQuery("INSERT INTO ... (col1, col2, ...) VALUES (?, ?, ...)", connection,
 ```
 **psResultQuery**
 ```c++
-psResultQuery("SELECT ... FROM ...", connection, <Callable>);
+psResultQuery(connection, "SELECT ... FROM ...", <Callable>);
 ```
 Where callable can be C function, lambda, or member function, however in the last case you need to use
 wrapper, for example wrapMember function (located in *superior_mysqlpp/extras/member_wrapper.hpp*).
 ```c++
-psResultQuery("SELECT ... FROM ...", connection, [&](int arg1, int arg2){});
+psResultQuery(connection, "SELECT ... FROM ...", [&](int arg1, int arg2){});
 ```
 ```c++
 void processRow(int arg1, int arg2) {}
-psResultQuery("SELECT ... FROM ...", connection, &processRow);
+psResultQuery(connection, "SELECT ... FROM ...", &processRow);
 ```
 ```c++
 class ProcessingClass {
@@ -291,7 +291,7 @@ public:
 };
 
 ProcessingClass pc;
-psResultQuery("SELECT ... FROM ...", connection, wrapMember(&pc, &ProcessingClass::processRow));
+psResultQuery(connection, "SELECT ... FROM ...", wrapMember(&pc, &ProcessingClass::processRow));
 ```
 This method doesn't throw exceptions, however query execution and row fetching can still fail,
 resulting in exception.
@@ -316,8 +316,8 @@ an *UnexpectedRowCountError* exception is thrown.
 int myData = 0;
 
 psQuery(
-    "SELECT ?",
     connection,
+    "SELECT ?",
     [&](int &value) -> bool {
         value = myData;
         return (myData++) < 5; // Return true, if data are set, false otherwise (no more input data available)

--- a/include/superior_mysqlpp/extras/prepared_statement_utils.hpp
+++ b/include/superior_mysqlpp/extras/prepared_statement_utils.hpp
@@ -110,7 +110,7 @@ namespace SuperiorMySqlpp
              typename ResultCallable,
              typename ParamCallable,
              typename ConnType>
-    void psQuery(const std::string &query, ConnType &&connection, ParamCallable &&paramsSetter, ResultCallable &&processingFunction)
+    void psQuery(ConnType &&connection, const std::string &query, ParamCallable &&paramsSetter, ResultCallable &&processingFunction)
     {
         static constexpr bool hasParamCallback = !std::is_same<ParamCallable, EmptyParamCallback>::value;
         static constexpr bool hasResultCallback = !std::is_same<ResultCallable, EmptyResultCallback>::value;
@@ -173,7 +173,7 @@ namespace SuperiorMySqlpp
              typename ConnType>
     [[deprecated("psReadQuery is deprecated, use psResultQuery")]] void psReadQuery(const std::string &query, ConnType &&connection, Callable &&processingFunction)
     {
-        psQuery(query, connection, EmptyParamCallback {}, processingFunction);
+        psQuery(connection, query, EmptyParamCallback {}, processingFunction);
     }
 
     /**
@@ -193,9 +193,9 @@ namespace SuperiorMySqlpp
              bool ignoreNullable=detail::PreparedStatementsDefault::getIgnoreNullable(),
              typename Callable,
              typename ConnType>
-    void psResultQuery(const std::string &query, ConnType &&connection, Callable &&processingFunction)
+    void psResultQuery(ConnType &&connection, const std::string &query, Callable &&processingFunction)
     {
-        psQuery(query, connection, EmptyParamCallback {}, processingFunction);
+        psQuery(connection, query, EmptyParamCallback {}, processingFunction);
     }
 
     /**
@@ -214,9 +214,9 @@ namespace SuperiorMySqlpp
              bool ignoreNullable=detail::PreparedStatementsDefault::getIgnoreNullable(),
              typename Callable,
              typename ConnType>
-    void psParamQuery(const std::string &query, ConnType &&connection, Callable &&paramsSetter)
+    void psParamQuery(ConnType &&connection, const std::string &query, Callable &&paramsSetter)
     {
-        psQuery(query, connection, paramsSetter, EmptyResultCallback {});
+        psQuery(connection, query, paramsSetter, EmptyResultCallback {});
     }
 
     /**

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -6,6 +6,7 @@ libsuperiormysqlpp (0.4.1) UNRELEASED; urgency=medium
 
   [ Michal Merc ]
   * feat: Implement psQuery/psParamQuery/psResultQuery convenience functions
+  * refactor: Change order of arguments for psQuery/psParamQuery/psResultQuery functions before release
 
  -- Peter Opatril <petr.opatril@firma.seznam.cz>  Fri, 24 May 2019 14:07:13 +0000
 

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -1,4 +1,4 @@
-libsuperiormysqlpp (0.4.1) UNRELEASED; urgency=medium
+libsuperiormysqlpp (0.5.0) UNRELEASED; urgency=medium
 
   [ Peter Opatril ]
   * refactor: Logging system (DRY)

--- a/tests/db_access/prepared_statements.cpp
+++ b/tests/db_access/prepared_statements.cpp
@@ -603,8 +603,8 @@ go_bandit([](){
         });
 
         it("can work with psResultQuery (valid types, passing query string)", [&](){
-            psResultQuery("SELECT `id`, `blob`, `binary`, `varbinary` FROM `test_superior_sqlpp`.`binary_data` ORDER BY `id` LIMIT 1",
-              connection, [&](int id, const BlobData &blob, const BlobData &binary, const BlobData &varbinary) {
+            psResultQuery(connection, "SELECT `id`, `blob`, `binary`, `varbinary` FROM `test_superior_sqlpp`.`binary_data` ORDER BY `id` LIMIT 1",
+              [&](int id, const BlobData &blob, const BlobData &binary, const BlobData &varbinary) {
                 AssertThat(id, Equals(42));
                 AssertThat(blob.size(), Equals(5u));
                 AssertThat(binary.size(), Equals(10u));
@@ -616,8 +616,8 @@ go_bandit([](){
         });
 
         it("can work with prepared statement helper functions - psResultQuery (invalid data types)", [&](){
-            AssertThrows(PreparedStatementTypeError, psResultQuery("SELECT `id`, `blob`, `binary`, `varbinary` FROM `test_superior_sqlpp`.`binary_data` ORDER BY `id` LIMIT 1",
-                connection, [&](int , int, const BlobData &, const BlobData &) {}));
+            AssertThrows(PreparedStatementTypeError, psResultQuery(connection, "SELECT `id`, `blob`, `binary`, `varbinary` FROM `test_superior_sqlpp`.`binary_data` ORDER BY `id` LIMIT 1",
+                [&](int , int, const BlobData &, const BlobData &) {}));
         });
 
         it("can work with psQuery helper function", [&](){
@@ -630,8 +630,8 @@ go_bandit([](){
 
             // Select ids, where foreign key is equal to some value (?)
             psQuery(
-                "SELECT `id`, `f_id` FROM `psquery_test` WHERE `f_id` = ?",
                 connection,
+                "SELECT `id`, `f_id` FROM `psquery_test` WHERE `f_id` = ?",
                 [&](int &f_id) -> bool {
                     if (foreignKeysIterator == std::end(foreignKeys))
                     {


### PR DESCRIPTION
This PR changes order of arguments of newly-created *psQuery* functions, before version containing them is released.