### PR TITLE
fix: validate integer convertor's values at compile time

### DIFF
--- a/include/superior_mysqlpp/converters/to_integer.hpp
+++ b/include/superior_mysqlpp/converters/to_integer.hpp
@@ -58,7 +58,7 @@ namespace Converters
             {
                 static constexpr T base = pow(10UL, length-1);
                 char c = *str;
-                AtCompileTime<validate>::invoke([c]()
+                CompileTimeIf<validate>::then([c]()
                 {
                     if (c < '0' || c > '9')
                     {
@@ -92,7 +92,7 @@ namespace Converters
             static inline void call(T& result, const char*& str) noexcept(!validate)
             {
                 char c = *str;
-                AtCompileTime<validate>::invoke([c]()
+                CompileTimeIf<validate>::then([c]()
                 {
                     if (c < '0' || c > '9')
                     {

--- a/include/superior_mysqlpp/converters/to_integer.hpp
+++ b/include/superior_mysqlpp/converters/to_integer.hpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <limits>
 #include <stdexcept>
+#include <superior_mysqlpp/utils.hpp>
 
 namespace SuperiorMySqlpp { 
 /**
@@ -57,13 +58,13 @@ namespace Converters
             {
                 static constexpr T base = pow(10UL, length-1);
                 char c = *str;
-                if (validate)
+                AtCompileTime<validate, !validate>::invoke([c]()
                 {
                     if (c < '0' || c > '9')
                     {
                         throw std::out_of_range("Character is not between 0 and 9!");
                     }
-                }
+                });
                 result += (c - '0') * base;
                 ++str;
                 ToIntegerParserImpl<T, length-1, validate>::call(result, str);
@@ -91,13 +92,13 @@ namespace Converters
             static inline void call(T& result, const char*& str) noexcept(!validate)
             {
                 char c = *str;
-                if (validate)
+                AtCompileTime<validate, !validate>::invoke([c]()
                 {
                     if (c < '0' || c > '9')
                     {
                         throw std::out_of_range("Character is not between 0 and 9!");
                     }
-                }
+                });
                 result += (c - '0');
                 ++str;
             }

--- a/include/superior_mysqlpp/converters/to_integer.hpp
+++ b/include/superior_mysqlpp/converters/to_integer.hpp
@@ -58,7 +58,7 @@ namespace Converters
             {
                 static constexpr T base = pow(10UL, length-1);
                 char c = *str;
-                AtCompileTime<validate, !validate>::invoke([c]()
+                AtCompileTime<validate>::invoke([c]()
                 {
                     if (c < '0' || c > '9')
                     {
@@ -92,7 +92,7 @@ namespace Converters
             static inline void call(T& result, const char*& str) noexcept(!validate)
             {
                 char c = *str;
-                AtCompileTime<validate, !validate>::invoke([c]()
+                AtCompileTime<validate>::invoke([c]()
                 {
                     if (c < '0' || c > '9')
                     {

--- a/include/superior_mysqlpp/utils.hpp
+++ b/include/superior_mysqlpp/utils.hpp
@@ -302,9 +302,9 @@ namespace SuperiorMySqlpp
      * @tparam Evaluate Flag if Invokable should be invoked
      */
     template<bool Evaluate>
-    struct AtCompileTime {
+    struct CompileTimeIf {
         template<typename Invokable>
-        static inline void invoke(Invokable &&) noexcept
+        static inline void then(Invokable &&) noexcept
         {
         }
     };
@@ -317,9 +317,9 @@ namespace SuperiorMySqlpp
      * @overload
      */
     template<>
-    struct AtCompileTime<true> {
+    struct CompileTimeIf<true> {
         template<typename Invokable>
-        static inline void invoke(Invokable &&invokable) noexcept(noexcept(std::declval<std::decay_t<Invokable>>()()))
+        static inline void then(Invokable &&invokable) noexcept(noexcept(std::declval<std::decay_t<Invokable>>()()))
         {
             invokable();
         }

--- a/include/superior_mysqlpp/utils.hpp
+++ b/include/superior_mysqlpp/utils.hpp
@@ -295,4 +295,35 @@ namespace SuperiorMySqlpp
      */
     template<typename T>
     struct FunctionInfo : FunctionInfo<decltype(&std::decay_t<T>::operator())> {};
+
+    /**
+     * @brief Calls function if Evaluate is true
+     *
+     * @tparam Evaluate Flag if Invokable should be invoked
+     * @tparam NoExcept Mark this function as noexcept?
+     */
+    template<bool Evaluate, bool NoExcept>
+    struct AtCompileTime {
+        template<typename Invokable>
+        static inline void invoke(Invokable &&) noexcept(NoExcept)
+        {
+        }
+    };
+
+    /**
+     * @brief Calls function if Evaluate is true
+     *
+     * @tparam Evaluate Flag if Invokable should be invoked
+     * @tparam NoExcept Mark this function as noexcept?
+     *
+     * @overload
+     */
+    template<bool NoExcept>
+    struct AtCompileTime<true, NoExcept> {
+        template<typename Invokable>
+        static inline void invoke(Invokable &&invokable) noexcept(NoExcept)
+        {
+            invokable();
+        }
+    };
 }

--- a/include/superior_mysqlpp/utils.hpp
+++ b/include/superior_mysqlpp/utils.hpp
@@ -300,12 +300,11 @@ namespace SuperiorMySqlpp
      * @brief Calls function if Evaluate is true
      *
      * @tparam Evaluate Flag if Invokable should be invoked
-     * @tparam NoExcept Mark this function as noexcept?
      */
-    template<bool Evaluate, bool NoExcept>
+    template<bool Evaluate>
     struct AtCompileTime {
         template<typename Invokable>
-        static inline void invoke(Invokable &&) noexcept(NoExcept)
+        static inline void invoke(Invokable &&) noexcept
         {
         }
     };
@@ -314,14 +313,13 @@ namespace SuperiorMySqlpp
      * @brief Calls function if Evaluate is true
      *
      * @tparam Evaluate Flag if Invokable should be invoked
-     * @tparam NoExcept Mark this function as noexcept?
      *
      * @overload
      */
-    template<bool NoExcept>
-    struct AtCompileTime<true, NoExcept> {
+    template<>
+    struct AtCompileTime<true> {
         template<typename Invokable>
-        static inline void invoke(Invokable &&invokable) noexcept(NoExcept)
+        static inline void invoke(Invokable &&invokable) noexcept(noexcept(std::declval<std::decay_t<Invokable>>()()))
         {
             invokable();
         }


### PR DESCRIPTION
Fix of error introduced when compiled with newer compilers (`-Werror=terminate`). Problem is that when you have noexcept function, you cannot discard the `throw` statement. This is fixed by introducing new facility to discard code if needed.