### PR TITLE
chore: Update bandit submodule to current HEAD

### DIFF
--- a/include/superior_mysqlpp/extras/row_stream_adapter.hpp
+++ b/include/superior_mysqlpp/extras/row_stream_adapter.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <cassert>
-
 #include <superior_mysqlpp/row.hpp>
 
 
@@ -48,7 +46,6 @@ namespace SuperiorMySqlpp { namespace Extras
         template<typename T>
         RowStreamAdapter& operator>>(T& obj)
         {
-            assert (*this);
             if (!(*first).isNull()) {
                 obj = (*first).to<T>();
             } else {

--- a/include/superior_mysqlpp/extras/row_stream_adapter.hpp
+++ b/include/superior_mysqlpp/extras/row_stream_adapter.hpp
@@ -1,4 +1,7 @@
 #pragma once
+
+#include <cassert>
+
 #include <superior_mysqlpp/row.hpp>
 
 

--- a/include/superior_mysqlpp/shared_ptr_pool/base.hpp
+++ b/include/superior_mysqlpp/shared_ptr_pool/base.hpp
@@ -13,6 +13,7 @@
 #include <future>
 #include <memory>
 #include <algorithm>
+#include <cassert>
 
 #include <superior_mysqlpp/traits.hpp>
 #include <superior_mysqlpp/logging.hpp>

--- a/include/superior_mysqlpp/shared_ptr_pool/sleep_in_parts.hpp
+++ b/include/superior_mysqlpp/shared_ptr_pool/sleep_in_parts.hpp
@@ -7,6 +7,7 @@
 
 #include <chrono>
 #include <thread>
+#include <cassert>
 
 
 namespace SuperiorMySqlpp { namespace detail

--- a/include/superior_mysqlpp/transaction.hpp
+++ b/include/superior_mysqlpp/transaction.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 
+#include <cassert>
+
 #include <superior_mysqlpp/connection_def.hpp>
 #include <superior_mysqlpp/query.hpp>
 #include <superior_mysqlpp/logging.hpp>

--- a/include/superior_mysqlpp/types/string_data.hpp
+++ b/include/superior_mysqlpp/types/string_data.hpp
@@ -9,7 +9,6 @@
 #include <string>
 #include <utility>
 #include <cstring>
-#include <cassert>
 
 #include <superior_mysqlpp/types/array.hpp>
 #include <superior_mysqlpp/types/string_view.hpp>

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -1,6 +1,7 @@
 libsuperiormysqlpp (0.5.1) UNRELEASED; urgency=medium
 
-  * 
+  [ Radek Smejdir ]
+  * chore: Update bandit submodule to current HEAD
 
  -- Peter Opatril <petr.opatril@firma.seznam.cz>  Thu, 20 Jun 2019 13:10:51 +0000
 

--- a/tests-extended/dnsa_connection_pool.cpp
+++ b/tests-extended/dnsa_connection_pool.cpp
@@ -16,6 +16,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace std::chrono_literals;
 

--- a/tests/converters/converters.cpp
+++ b/tests/converters/converters.cpp
@@ -9,6 +9,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 
 

--- a/tests/db_access/connection.cpp
+++ b/tests/db_access/connection.cpp
@@ -13,6 +13,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 
 

--- a/tests/db_access/connection_pool.cpp
+++ b/tests/db_access/connection_pool.cpp
@@ -16,6 +16,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace std::string_literals;
 using namespace std::chrono_literals;

--- a/tests/db_access/driver.cpp
+++ b/tests/db_access/driver.cpp
@@ -11,6 +11,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace SuperiorMySqlpp::LowLevel;
 using namespace std::string_literals;

--- a/tests/db_access/dynamic_prepared_statements.cpp
+++ b/tests/db_access/dynamic_prepared_statements.cpp
@@ -12,6 +12,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 
 
@@ -228,7 +229,7 @@ go_bandit([](){
             preparedStatement.bindResult(0, id);
             AssertThrows(OutOfRange, preparedStatement.bindResult(1, id));
         });
-        
+
         it("can validate nullable value", [&](){
             int id = 666;
             std::string name{"Diablo"};
@@ -250,7 +251,7 @@ go_bandit([](){
                     );
                 preparedStatement.bindParam(0, id);
                 preparedStatement.updateParamBindings();
-                
+
                 preparedStatement.execute();
 
                 Nullable<Sql::Int> nullable_id;
@@ -260,10 +261,10 @@ go_bandit([](){
                 preparedStatement.updateResultBindings();
 
                 AssertThat(preparedStatement.fetch(), IsTrue());
-                
+
                 AssertThat(nullable_id.isValid(), IsTrue());
                 AssertThat(nullable_id.value(), Equals(id));
-                
+
                 AssertThat(nullable_name.isValid(), IsTrue());
                 AssertThat(nullable_name.value(), Equals(name));
             }

--- a/tests/db_access/master_slave_connection_pools.cpp
+++ b/tests/db_access/master_slave_connection_pools.cpp
@@ -14,6 +14,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace std::string_literals;
 using namespace std::chrono_literals;

--- a/tests/db_access/metadata.cpp
+++ b/tests/db_access/metadata.cpp
@@ -10,6 +10,7 @@
 #include "settings.hpp"
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 
 

--- a/tests/db_access/prepared_statements.cpp
+++ b/tests/db_access/prepared_statements.cpp
@@ -13,6 +13,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace std::string_literals;
 

--- a/tests/db_access/query_escaping.cpp
+++ b/tests/db_access/query_escaping.cpp
@@ -10,6 +10,7 @@
 #include "settings.hpp"
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 
 

--- a/tests/db_access/row.cpp
+++ b/tests/db_access/row.cpp
@@ -10,6 +10,7 @@
 #include "settings.hpp"
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 
 go_bandit([](){

--- a/tests/db_access/row_stream_adapter.cpp
+++ b/tests/db_access/row_stream_adapter.cpp
@@ -9,6 +9,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 
 go_bandit([](){

--- a/tests/db_access/simple_result.cpp
+++ b/tests/db_access/simple_result.cpp
@@ -10,6 +10,7 @@
 #include "settings.hpp"
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 
 

--- a/tests/db_access/store_result.cpp
+++ b/tests/db_access/store_result.cpp
@@ -12,6 +12,7 @@
 #include "settings.hpp"
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace SuperiorMySqlpp::StringViewLiterals;
 using namespace std::string_literals;

--- a/tests/db_access/transactions.cpp
+++ b/tests/db_access/transactions.cpp
@@ -11,6 +11,7 @@
 #include "settings.hpp"
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 
 

--- a/tests/traits.cpp
+++ b/tests/traits.cpp
@@ -9,6 +9,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace SuperiorMySqlpp::Traits;
 

--- a/tests/types/array.cpp
+++ b/tests/types/array.cpp
@@ -10,6 +10,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace std::string_literals;
 

--- a/tests/types/concat_iterator.cpp
+++ b/tests/types/concat_iterator.cpp
@@ -11,6 +11,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace std::string_literals;
 

--- a/tests/types/date.cpp
+++ b/tests/types/date.cpp
@@ -10,6 +10,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace std::string_literals;
 

--- a/tests/types/datetime.cpp
+++ b/tests/types/datetime.cpp
@@ -10,6 +10,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace std::string_literals;
 

--- a/tests/types/decimal_data.cpp
+++ b/tests/types/decimal_data.cpp
@@ -10,6 +10,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace std::string_literals;
 

--- a/tests/types/loggers.cpp
+++ b/tests/types/loggers.cpp
@@ -10,6 +10,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace std::string_literals;
 

--- a/tests/types/nullable.cpp
+++ b/tests/types/nullable.cpp
@@ -9,6 +9,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace std::string_literals;
 

--- a/tests/types/string_data.cpp
+++ b/tests/types/string_data.cpp
@@ -10,6 +10,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace std::string_literals;
 

--- a/tests/types/time.cpp
+++ b/tests/types/time.cpp
@@ -10,6 +10,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 using namespace std::string_literals;
 

--- a/tests/uncaught_exception_counter.cpp
+++ b/tests/uncaught_exception_counter.cpp
@@ -9,6 +9,7 @@
 
 
 using namespace bandit;
+using namespace snowhouse;
 using namespace SuperiorMySqlpp;
 
 


### PR DESCRIPTION
Fix header includes and `using namespace snowhouse` because assertion helpers were moved to this namespace.