### PR TITLE
Fix verbose error logging in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,12 @@
-debian/
+**/debian/*
+!debian/control
+!debian/changelog
+!debian/rules
+!debian/compat
+!debian/libsuperiormysqlpp-dev.install
+!debian/libsuperiormysqlpp.install
+!debian/libsuperiormysqlpp.links
+
 *.deb
 *.changes
 
@@ -11,6 +19,7 @@ debian/
 
 *.d
 *.o
+*.swp
 
 odr_program
 tester

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -1,6 +1,7 @@
 libsuperiormysqlpp (0.5.2) UNRELEASED; urgency=medium
 
-  *
+  [ Peter Opatril ]
+  * fix: silence expected connection errors in tests
 
  -- Radek Smejdir <radek.smejdir@firma.seznam.cz>  Wed, 24 Jul 2019 14:28:41 +0200
 

--- a/tests-extended/dnsa_connection_pool.cpp
+++ b/tests-extended/dnsa_connection_pool.cpp
@@ -120,14 +120,24 @@ go_bandit([]() {
 
         it("reconnects after dns change", [&]() {
 
+            auto&& standardLogger = DefaultLogger::getLoggerPtr();
+            auto&& silentLogger = std::make_shared<Loggers::Base>();
+
             HostnameGuard hostnameGuard{};
             // set "invalid" ip address, connections cannot be created
             setIpForHostname("1.1.1.1", hostname);
 
             auto settings = getSettingsRef();
+
+            // Silences logging, notably the logSharedPtrPoolResourceCountKeeperAddingResourcesException case
+            DefaultLogger::setLoggerPtr(silentLogger);
+
             auto pool = makeTestPool(settings, hostname);
 
             setupTestPool(pool);
+
+            // Recover conventional logging
+            DefaultLogger::setLoggerPtr(standardLogger);
 
             // check that we cannot create connections
             AssertThat(pool.poolState().available, Equals(0u));


### PR DESCRIPTION
Silences technically correct, but unpleasant spamming of connection errors in test's logs.
Also features minor gitignore fix.