### PR TITLE
feat: ignore timestamp signedness

### DIFF
--- a/include/superior_mysqlpp/prepared_statements/initialize_bindings.hpp
+++ b/include/superior_mysqlpp/prepared_statements/initialize_bindings.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-
 #include <superior_mysqlpp/prepared_statements/get_binding_type.hpp>
 #include <superior_mysqlpp/prepared_statements/binding_types.hpp>
 #include <superior_mysqlpp/types/blob_data.hpp>

--- a/include/superior_mysqlpp/prepared_statements/validate_metadata_modes.hpp
+++ b/include/superior_mysqlpp/prepared_statements/validate_metadata_modes.hpp
@@ -124,6 +124,24 @@ namespace SuperiorMySqlpp
     }
 
     /**
+     * Returns true if field type uses is_unsigned field
+     */
+    inline bool fieldTypeHasSign(FieldTypes type)
+    {
+        if (type == FieldTypes::Timestamp)
+            return false;
+        return true;
+    }
+
+    /**
+     * Returns true, if both types matches their signedness or given type has no signedness
+     */
+    inline bool fieldSignsMatch(FieldTypes from, bool from_is_unsigned, FieldTypes to, bool to_is_unsigned)
+    {
+        return from_is_unsigned == to_is_unsigned || !(fieldTypeHasSign(from) || fieldTypeHasSign(to));
+    }
+
+    /**
      * @brief Tests whether one argument is convertible to the other
      * Implementation depends on selected validation strategy
      * @params from Input field type.
@@ -145,13 +163,13 @@ namespace SuperiorMySqlpp
     template<>
     inline bool isCompatible<ValidateMetadataMode::Strict>(FieldTypes from, bool from_is_unsigned, FieldTypes to, bool to_is_unsigned)
     {
-        return from==to && from_is_unsigned==to_is_unsigned;
+        return from==to && fieldSignsMatch(from, from_is_unsigned, to, to_is_unsigned);
     }
 
     template<>
     inline bool isCompatible<ValidateMetadataMode::Same>(FieldTypes from, bool from_is_unsigned, FieldTypes to, bool to_is_unsigned)
     {
-        if (from_is_unsigned != to_is_unsigned)
+        if (!fieldSignsMatch(from, from_is_unsigned, to, to_is_unsigned))
         {
             return false;
         }
@@ -169,7 +187,7 @@ namespace SuperiorMySqlpp
     template<>
     inline bool isCompatible<ValidateMetadataMode::ArithmeticPromotions>(FieldTypes from, bool from_is_unsigned, FieldTypes to, bool to_is_unsigned)
     {
-        if (!from_is_unsigned && to_is_unsigned)
+        if (!from_is_unsigned && to_is_unsigned && fieldTypeHasSign(from) && fieldTypeHasSign(to))
         {
             return false;
         }

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -3,6 +3,9 @@ libsuperiormysqlpp (0.5.2) UNRELEASED; urgency=medium
   [ Peter Opatril ]
   * fix: silence expected connection errors in tests
 
+  [ Michal Merc ]
+  * feat: ignore timestamp signedness
+
  -- Radek Smejdir <radek.smejdir@firma.seznam.cz>  Wed, 24 Jul 2019 14:28:41 +0200
 
 libsuperiormysqlpp (0.5.1) unstable; urgency=medium


### PR DESCRIPTION
Different versions of MySql gives different timestamp signedness. This adds ability to overload prepared statement's checks.