### PR TITLE
feat: Use converter struct instead of converter function

### DIFF
--- a/include/superior_mysqlpp/converters.hpp
+++ b/include/superior_mysqlpp/converters.hpp
@@ -14,22 +14,58 @@
 
 namespace SuperiorMySqlpp { namespace Converters
 {
-    template<typename T>
-    inline std::enable_if_t<std::is_integral<T>::value, T> to(const char* str, unsigned int length)
-    {
-        return toInteger<T>(str, length);
+    template<typename, typename=void>
+    struct To;
+
+    namespace detail {
+        template<typename... Ts> struct make_void { typedef void type;};
+        template<typename... Ts> using void_t = typename make_void<Ts...>::type;
+
+        template<typename T>
+        using get_to_method_type = decltype(&To<T>::operator());
+
+        template<typename T, typename = void>
+        struct has_to_overload : std::false_type {};
+
+        template<typename T>
+        struct has_to_overload<T, void_t<get_to_method_type<T>>> : std::true_type {};
+
     }
 
     template<typename T>
-    inline std::enable_if_t<std::is_floating_point<T>::value, T> to(const char* str, unsigned int length)
-    {
-        return toFloatingPoint<T>(str, length);
-    }
+    struct To<T, std::enable_if_t<std::is_integral<T>::value>> {
+        T operator()(const char* str, unsigned int length) {
+            return toInteger<T>(str, length);
+        }
+    };
 
     template<typename T>
-    inline std::enable_if_t<std::is_same<T, std::string>::value, T> to(const char* str, unsigned int length)
+    struct To<T, std::enable_if_t<std::is_floating_point<T>::value>> {
+        T operator()(const char* str, unsigned int length) {
+            return toFloatingPoint<T>(str, length);
+        }
+    };
+
+    template<typename T>
+    struct To<T, std::enable_if_t<std::is_same<T, std::string>::value>> {
+        T operator()(const char* str, unsigned int length) {
+            return {str, length};
+        }
+    };
+
+    /*
+     * Support wrapper for old-style custom converters
+     *
+     * This wrapper is active only when appropriate `To` struct is defined (either here or by the user),
+     * thus allowing the existing `to<T>` overloads to function as they did before and simlutaneously
+     * enabling the user to define new `To` converters which can be defined with no respect to include order
+     * (unlike the old-style way, which needed the specializations to be defined before the main header
+     * inclusion)
+     */
+    template<typename T>
+    inline std::enable_if_t<detail::has_to_overload<T>::value, T> to(const char* str, unsigned int length)
     {
-        return {str, length};
+        return To<T>{}(str, length);
     }
 
     template<typename T, typename std::enable_if<std::is_arithmetic<T>::value, int>::type=0>

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -1,8 +1,8 @@
-libsuperiormysqlpp (0.5.3) UNRELEASED; urgency=medium
+libsuperiormysqlpp (0.6.0) UNRELEASED; urgency=medium
 
-  * 
+  * feat: use converter struct instead of converter function
 
- -- Peter Opatril <petr.opatril@firma.seznam.cz>  Thu, 19 Sep 2019 14:29:27 +0200
+ -- Jan Kriho <jan.kriho@firma.seznam.cz>  Tue, 24 Sep 2019 11:08:31 +0200
 
 libsuperiormysqlpp (0.5.2) unstable; urgency=medium
 

--- a/tests/converters/converters.cpp
+++ b/tests/converters/converters.cpp
@@ -4,9 +4,54 @@
 
 #include <string>
 #include <bandit/bandit.h>
-
 #include <superior_mysqlpp/converters.hpp>
 
+struct Foo {
+    int intValue;
+    Foo(int intValue) : intValue(intValue) {}
+
+    bool operator==(const Foo &other) const {
+        return intValue == other.intValue;
+    }
+};
+
+struct Bar {
+    int intValue;
+    Bar(int intValue) : intValue(intValue) {}
+
+    bool operator==(const Bar &other) const {
+        return intValue == other.intValue;
+    }
+};
+
+
+
+namespace SuperiorMySqlpp { namespace Converters {
+    template<typename T>
+    inline std::enable_if_t<std::is_same<T, Foo>::value, T> to(
+        const char* str,
+        unsigned int length
+    ) {
+        return to<int>(str, length);
+    }
+
+}}
+
+template<typename T>
+T decode(const char* str, unsigned int length) {
+    return SuperiorMySqlpp::Converters::to<T>(str, length);
+}
+
+namespace SuperiorMySqlpp { namespace Converters {
+
+    template<typename T>
+    struct To<T, std::enable_if_t<std::is_same<T, Bar>::value>> {
+        T operator()(const char* str, unsigned int length) {
+            return To<int>{}(str, length);
+        }
+    };
+
+}}
 
 using namespace bandit;
 using namespace snowhouse;
@@ -19,6 +64,16 @@ go_bandit([](){
             std::string s{"125"};
             auto i = Converters::to<int>(s.data(), s.length());
             AssertThat(i, Equals(125));
+        });
+        it("can custom-convert old-style", [&](){
+            std::string s{"125"};
+            auto i = Converters::to<Foo>(s.data(), s.length());
+            AssertThat(i, Equals(Foo{125}));
+        });
+        it("can custom-convert new-style", [&](){
+            std::string s{"125"};
+            auto i = Converters::to<Bar>(s.data(), s.length());
+            AssertThat(i, Equals(Bar{125}));
         });
     });
 });


### PR DESCRIPTION
Fixes #123 with backward compatibility for existing user-defined converters