### PR TITLE
fix: type validation not ignoring is_unsigned for types like float

### DIFF
--- a/include/superior_mysqlpp/prepared_statements/validate_metadata_modes.hpp
+++ b/include/superior_mysqlpp/prepared_statements/validate_metadata_modes.hpp
@@ -128,9 +128,38 @@ namespace SuperiorMySqlpp
      */
     inline bool fieldTypeHasSign(FieldTypes type)
     {
-        if (type == FieldTypes::Timestamp)
-            return false;
-        return true;
+        switch (type)
+        {
+            case FieldTypes::Tiny:
+            case FieldTypes::Short:
+            case FieldTypes::Int24:
+            case FieldTypes::Long:
+            case FieldTypes::LongLong:
+                return true;
+
+            case FieldTypes::Float:
+            case FieldTypes::Double:
+            case FieldTypes::Decimal:
+            case FieldTypes::NewDecimal:
+            case FieldTypes::Time:
+            case FieldTypes::Date:
+            case FieldTypes::Datetime:
+            case FieldTypes::Timestamp:
+            case FieldTypes::Year:
+            case FieldTypes::String:
+            case FieldTypes::VarString:
+            case FieldTypes::Enum:
+            case FieldTypes::Set:
+            case FieldTypes::Bit:
+            case FieldTypes::Blob:
+            case FieldTypes::TinyBlob:
+            case FieldTypes::MediumBlob:
+            case FieldTypes::LongBlob:
+            case FieldTypes::Geometry:
+            case FieldTypes::Null:
+            default:
+                return false;
+        }
     }
 
     /**

--- a/packages/_debian-common/changelog
+++ b/packages/_debian-common/changelog
@@ -1,8 +1,9 @@
 libsuperiormysqlpp (0.6.1) UNRELEASED; urgency=medium
 
-  *
+  [ Peter Opatril ]
+  * fix: type validation not ignoring is_unsigned for types like float
 
- -- Radek Smejdir <radek.smejdir@firma.seznam.cz>  Mon, 02 Dec 2019 13:52:26 +0100
+ -- Peter Opatril <petr.opatril@firma.seznam.cz>  Thu, 30 Jul 2020 18:47:22 +0200
 
 libsuperiormysqlpp (0.6.0) unstable; urgency=medium
 


### PR DESCRIPTION
Ignores is_unsigned boolean from C mysql library for types that shouldn't be signed in validation.

Fixes unusual validation warnings such as
```
PS [1]: Result types at index 1 does not match. In validate mode "Same", expected type "Float" is not compatible with result type "Float"
```