### PR TITLE
Multiple definition of mapSecondGetter function

### DIFF
--- a/include/superior_mysqlpp/master_slave_connection_pools.hpp
+++ b/include/superior_mysqlpp/master_slave_connection_pools.hpp
@@ -17,8 +17,9 @@
 
 namespace SuperiorMySqlpp
 {
-    inline auto mapSecondGetter = [](auto&& item) -> auto& { return std::forward<decltype(item)>(item).second; };
-
+    template <typename T>
+    T& mapSecondGetter(T&& item) { return std::forward<T>(item).second; }
+    
     template<
         typename SharedPtrPoolType,
         typename SlaveId=unsigned int

--- a/include/superior_mysqlpp/master_slave_connection_pools.hpp
+++ b/include/superior_mysqlpp/master_slave_connection_pools.hpp
@@ -17,8 +17,7 @@
 
 namespace SuperiorMySqlpp
 {
-    template <typename T>
-    T& mapSecondGetter(T&& item) { return std::forward<T>(item).second; }
+    const auto mapSecondGetter = [](auto&& item) -> auto& { return std::forward<decltype(item)>(item).second; };
     
     template<
         typename SharedPtrPoolType,

--- a/include/superior_mysqlpp/master_slave_connection_pools.hpp
+++ b/include/superior_mysqlpp/master_slave_connection_pools.hpp
@@ -17,7 +17,7 @@
 
 namespace SuperiorMySqlpp
 {
-    auto mapSecondGetter = [](auto&& item) -> auto& { return std::forward<decltype(item)>(item).second; };
+    inline auto mapSecondGetter = [](auto&& item) -> auto& { return std::forward<decltype(item)>(item).second; };
 
     template<
         typename SharedPtrPoolType,


### PR DESCRIPTION
An `inline` is missed in the global lambda function `mapSecondGetter`. 
Without it, a linker error is produced when the header file `superior_mysqlpp.hpp` is included in more than one translation unit