### PR TITLE
Debian bullseye

### DIFF
--- a/include/superior_mysqlpp/shared_ptr_pool/base.hpp
+++ b/include/superior_mysqlpp/shared_ptr_pool/base.hpp
@@ -313,7 +313,7 @@ public:
         std::unique_lock<PoolMutex_t> lock{poolMutex};
         auto populationId = getPopulationId();
 
-        assert((pool.size()==0 && poolIndex==0) || (pool.size()>0 && (poolIndex>=0 && poolIndex<pool.size())));
+        assert((pool.size()==0 && poolIndex==0) || (pool.size()>0 && poolIndex<pool.size()));
 
         auto poolIndexIt = pool.begin() + poolIndex;
 

--- a/tests/db/Dockerfile
+++ b/tests/db/Dockerfile
@@ -25,6 +25,7 @@ ADD supervisord.conf /etc/supervisor/supervisord.conf
 
 # Enable mysqld socket (for testing purposes)
 RUN echo "socket = /var/run/mysqld/mysqld.sock" >> /etc/mysql/conf.d/mysql.cnf
+RUN printf '\n[mysqld]\ntls_version=TLSv1.2\n' >> /etc/mysql/conf.d/mysql.cnf
 
 # Tunnel 3307 port to previously defined socket
 ADD mysql-socket-tunnel-3307 /usr/sbin/mysql-socket-tunnel-3307

--- a/tests/db_access/metadata.cpp
+++ b/tests/db_access/metadata.cpp
@@ -88,6 +88,11 @@ go_bandit([](){
         auto& s = getSettingsRef();
         Connection connection{s.database, s.user, s.password, s.host, s.port};
 
+        {
+            auto query = connection.makeQuery("SET NAMES latin1");
+            query.execute();
+        }
+
         it("can do StoreQuery metadata", [&](){
             auto query = connection.makeQuery(queryString);
             query.execute();


### PR DESCRIPTION
Fix Debian Bullseye build & tests:

1. https://github.com/seznam/SuperiorMySqlpp/commit/7dffb3aa0cf07f8370ea54c039034090cda79900 (fix gcc 10 warning):
```
./libsuperiormysqlpp/include/superior_mysqlpp/shared_ptr_pool/base.hpp:316:80: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
  316 |         assert((pool.size()==0 && poolIndex==0) || (pool.size()>0 && (poolIndex>=0 && poolIndex<pool.size())));
      |                                                                       ~~~~~~~~~^~~
```

2. https://github.com/seznam/SuperiorMySqlpp/commit/11236996ca3f93b89df60acac67d57894683d0b7 (fix SSL tests):
```
1: describe Test connection
1:      - it will initialize ... OK
1:      - it will can have pre-connect arguments ... OK
1:      - it can be moved between threads ... OK
1:      - it can use SSL ... FAILED
1:      - it can use TCP ConnectionConfiguration without SSL ... OK
1:      - it can use TCP ConnectionConfiguration with SSL ... FAILED
1:      - it can use socketed ConnectionConfiguration without SSL ... OK
1:      - it can use socketed ConnectionConfiguration with SSL ... 2021/09/20 10:02:31 socat[328033] E write(7, 0x561012272000, 26): Broken pipe
1: FAILED
1:      - it does not crash when stealing connection ... OK

...

1: Test connection can use SSL:
1: exception: Failed to connect to MySQL. (Host: 172.17.0.2; User: root; Database: test_superior_sqlpp; Port: 3306; SocketName: 
1: Mysql error: SSL connection error: unsupported protocol
1: 
1: Test connection can use TCP ConnectionConfiguration with SSL:
1: exception: Failed to connect to MySQL. (Host: 172.17.0.2; User: root; Database: test_superior_sqlpp; Port: 3306; SocketName: 
1: Mysql error: SSL connection error: unsupported protocol
1: 
1: Test connection can use socketed ConnectionConfiguration with SSL:
1: exception: Failed to connect to MySQL. (Host: ; User: root; Database: test_superior_sqlpp; Port: 0; SocketName: /tmp/smpp-superiormysqlpp-testdb.sock
1: Mysql error: SSL connection error: unsupported protocol
```

3. https://github.com/seznam/SuperiorMySqlpp/commit/683446ce5bfb351ecf901aef071bdfd6dfb768b5 (fix metadata tests):
```
1: describe Test metadata
1:      - it can do StoreQuery metadata ... FAILED
1:      - it is iterable ... OK
1:      - it can do UseQuery metadata ... FAILED
1:      - it can do PreparedStatement metadata ... FAILED
1:      - it can do PreparedStatement metadata without execute ... FAILED
1:      - it can do DynamicPreparedStatement metadata without execute ... FAILED

...

1: Test metadata can do StoreQuery metadata:
1: ./SuperiorMySqlpp/tests/db_access/metadata.cpp:56: Expected: equal to 8
1: Actual: 45
1: 
1: 
1: Test metadata can do UseQuery metadata:
1: ./SuperiorMySqlpp/tests/db_access/metadata.cpp:56: Expected: equal to 8
1: Actual: 45
1: 
1: 
1: Test metadata can do PreparedStatement metadata:
1: ./SuperiorMySqlpp/tests/db_access/metadata.cpp:56: Expected: equal to 8
1: Actual: 45
1: 
1: 
1: Test metadata can do PreparedStatement metadata without execute:
1: ./SuperiorMySqlpp/tests/db_access/metadata.cpp:56: Expected: equal to 8
1: Actual: 45
1: 
1: 
1: Test metadata can do DynamicPreparedStatement metadata without execute:
1: ./SuperiorMySqlpp/tests/db_access/metadata.cpp:56: Expected: equal to 8
1: Actual: 45
```
