### PR TITLE
chore: update docker image for tests

### DIFF
--- a/tests/db/Dockerfile
+++ b/tests/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.7.22
+FROM mysql:5.7.42-debian
 MAINTAINER Seznam.cz a.s.
 
 WORKDIR /

--- a/tests/db/docker-entrypoint.sh.patch
+++ b/tests/db/docker-entrypoint.sh.patch
@@ -1,4 +1,4 @@
-133c133
-< exec "$@"
+431c431
+< 	exec "$@"
 ---
-> exec /usr/bin/supervisord
+> 	exec /usr/bin/supervisord


### PR DESCRIPTION
old `mysql:5.7.22` doesn't work anymore

```
1: DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
1:             Install the buildx component to build images with BuildKit:
1:             https://docs.docker.com/go/buildx/
1: 
1: Sending build context to Docker daemon  11.78kB
1: Step 1/15 : FROM mysql:5.7.22
1: 5.7.22: Pulling from library/mysql
1: Digest: sha256:aaba540cdd9313645d892f4f20573e8b42b30e5be71c054b7befed2f7da5f85b
1: Status: Image is up to date for mysql:5.7.22
1:  ---> 6bb891430fb6
1: Step 2/15 : MAINTAINER Seznam.cz a.s.
1:  ---> Using cache
1:  ---> 7becf5f8322a
1: Step 3/15 : WORKDIR /
1:  ---> Using cache
1:  ---> bca4c73361f0
1: Step 4/15 : ENV MYSQL_ROOT_PASSWORD password
1:  ---> Using cache
1:  ---> a9bcb4f1b550
1: Step 5/15 : ADD test_database.sql /docker-entrypoint-initdb.d/
1:  ---> Using cache
1:  ---> 63f759a71b4a
1: Step 6/15 : RUN apt-get update && apt-get install -y     patch     socat     supervisor && rm -rf /var/lib/apt/lists/*
1:  ---> Running in 0420e4a1548e
1: Ign:1 http://security.debian.org/debian-security stretch/updates InRelease
1: Ign:2 http://deb.debian.org/debian stretch InRelease
1: Ign:3 http://security.debian.org/debian-security stretch/updates Release
1: Ign:4 http://deb.debian.org/debian stretch-updates InRelease
1: Ign:5 http://security.debian.org/debian-security stretch/updates/main all Packages
1: Ign:6 http://deb.debian.org/debian stretch Release
1: Get:7 http://repo.mysql.com/apt/debian stretch InRelease [21.6 kB]
1: Ign:8 http://deb.debian.org/debian stretch-updates Release
1: Ign:9 http://security.debian.org/debian-security stretch/updates/main amd64 Packages
1: Ign:5 http://security.debian.org/debian-security stretch/updates/main all Packages
1: Ign:10 http://deb.debian.org/debian stretch/main amd64 Packages
1: Ign:11 http://deb.debian.org/debian stretch/main all Packages
1: Ign:9 http://security.debian.org/debian-security stretch/updates/main amd64 Packages
1: Ign:5 http://security.debian.org/debian-security stretch/updates/main all Packages
1: Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
1: Ign:9 http://security.debian.org/debian-security stretch/updates/main amd64 Packages
1: Ign:13 http://deb.debian.org/debian stretch-updates/main amd64 Packages
1: Ign:5 http://security.debian.org/debian-security stretch/updates/main all Packages
1: Ign:10 http://deb.debian.org/debian stretch/main amd64 Packages
1: Ign:9 http://security.debian.org/debian-security stretch/updates/main amd64 Packages
1: Ign:11 http://deb.debian.org/debian stretch/main all Packages
1: Ign:5 http://security.debian.org/debian-security stretch/updates/main all Packages
1: Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
1: Ign:9 http://security.debian.org/debian-security stretch/updates/main amd64 Packages
1: Ign:5 http://security.debian.org/debian-security stretch/updates/main all Packages
1: Ign:13 http://deb.debian.org/debian stretch-updates/main amd64 Packages
1: Err:9 http://security.debian.org/debian-security stretch/updates/main amd64 Packages
1:   404  Not Found [IP: 151.101.66.132 80]
1: Ign:10 http://deb.debian.org/debian stretch/main amd64 Packages
1: Ign:11 http://deb.debian.org/debian stretch/main all Packages
1: Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
1: Ign:13 http://deb.debian.org/debian stretch-updates/main amd64 Packages
1: Ign:10 http://deb.debian.org/debian stretch/main amd64 Packages
1: Ign:11 http://deb.debian.org/debian stretch/main all Packages
1: Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
1: Ign:7 http://repo.mysql.com/apt/debian stretch InRelease
1: Ign:13 http://deb.debian.org/debian stretch-updates/main amd64 Packages
1: Get:14 http://repo.mysql.com/apt/debian stretch/mysql-5.7 amd64 Packages [5688 B]
1: Ign:10 http://deb.debian.org/debian stretch/main amd64 Packages
1: Ign:11 http://deb.debian.org/debian stretch/main all Packages
1: Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
1: Ign:13 http://deb.debian.org/debian stretch-updates/main amd64 Packages
1: Err:10 http://deb.debian.org/debian stretch/main amd64 Packages
1:   404  Not Found
1: Ign:11 http://deb.debian.org/debian stretch/main all Packages
1: Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
1: Err:13 http://deb.debian.org/debian stretch-updates/main amd64 Packages
1:   404  Not Found
1: Fetched 27.3 kB in 0s (86.8 kB/s)
1: Reading package lists...
1: W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
1: W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
1: W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
1: W: GPG error: http://repo.mysql.com/apt/debian stretch InRelease: The following signatures were invalid: EXPKEYSIG 8C718D3B5072E1F5 MySQL Release Engineering <mysql-build@oss.oracle.com>
1: W: The repository 'http://repo.mysql.com/apt/debian stretch InRelease' is not signed.
1: E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.66.132 80]
1: E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
1: E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found
1: E: Some index files failed to download. They have been ignored, or old ones used instead.
1: The command '/bin/sh -c apt-get update && apt-get install -y     patch     socat     supervisor && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
1/1 Test #1: test_main ........................***Failed    1.84 sec

0% tests passed, 1 tests failed out of 1
```