### PR TITLE
Fix github actions & tests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -15,7 +15,7 @@ jobs:
           submodules: recursive
 
     - name: Install dependencies
-      run: sudo apt-get install libboost-system-dev libmysqlclient-dev socat
+      run: sudo apt-get install libboost-system-dev libmariadb-dev-compat socat
 
     - name: Configure CMake
       run: |

--- a/tests/db/Dockerfile
+++ b/tests/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.7.22
+FROM mysql:5.7.42-debian
 MAINTAINER Seznam.cz a.s.
 
 WORKDIR /

--- a/tests/db/docker-entrypoint.sh.patch
+++ b/tests/db/docker-entrypoint.sh.patch
@@ -1,4 +1,4 @@
-133c133
-< exec "$@"
+431c431
+< 	exec "$@"
 ---
-> exec /usr/bin/supervisord
+> 	exec /usr/bin/supervisord


### PR DESCRIPTION
Based on https://github.com/seznam/SuperiorMySqlpp/pull/141, but with repaired CI - previously used image is not avaialable and what is available only has mysql 8.0 client, which we don't support, so we had to move to MariaDB equivalent.